### PR TITLE
Agregar autenticación a API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # backend [![Build Status](https://travis-ci.org/LinkUpFiuba/backend.svg?branch=master)](https://travis-ci.org/LinkUpFiuba/backend)
 
-### Configuración
+## Configuración
 Para correr el servidor, es necesario tener seteada la variable de ambiente `FIREBASE_PRIVATE_KEY` con la clave privada que se encuentra en el [archivo generado](https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk?hl=es-419) por Firebase. Si no posee dicho archivo, contáctese para obtener dicha clave privada.
+
+## API
+_**Nota:** todos los requests que se hacen deben contener un header con 'token' como clave y el valor del token del usuario como valor_
+
+### - `/users`
+Devuelve todos los usuarios posibles de linkeo con el usuario que hace el request.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import UserService from './services/userService'
+import Administrator from './services/gateway/administrator'
 import bodyParser from 'body-parser'
 
 const app = express()
@@ -17,9 +18,9 @@ app.set('view engine', 'ejs')
 app.post('/users', (request, response) => {
   UserService().createUser(request.body)
     .then(() => response.status(201).send())
-    .catch(err => {
+    .catch(error => {
       response.status(400)
-      return response.json({ message: err })
+      return response.json({ message: error })
     })
 })
 
@@ -28,7 +29,19 @@ app.get('/users/:id', (request, response) => {
 })
 
 app.get('/users', (request, response) => {
-  UserService().getAllUsers().then(users => response.json(users))
+  if (!request.get('token')) {
+    response.status(400)
+    return response.json({ message: 'El header "token" debe enviarse como parte del request' })
+  }
+  Administrator().auth().verifyIdToken(request.get('token'))
+    .then(decodedToken => {
+      const uid = decodedToken.uid
+      UserService(uid).getAllUsers().then(users => response.json(users))
+    })
+    .catch(error => {
+      response.status(401)
+      return response.json({ message: error })
+    })
 })
 
 app.listen(app.get('port'), () => {

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ app.get('/users', (request, response) => {
   Administrator().auth().verifyIdToken(request.get('token'))
     .then(decodedToken => {
       const uid = decodedToken.uid
-      UserService(uid).getAllUsers().then(users => response.json(users))
+      UserService().getAllUsers(uid).then(users => response.json(users))
     })
     .catch(error => {
       response.status(401)

--- a/src/services/gateway/administrator.js
+++ b/src/services/gateway/administrator.js
@@ -1,0 +1,15 @@
+import * as admin from 'firebase-admin'
+
+export default () => {
+  if (admin.apps.length === 0) {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: 'linkup-7739d',
+        clientEmail: 'firebase-adminsdk-7txkj@linkup-7739d.iam.gserviceaccount.com',
+        privateKey: process.env.FIREBASE_PRIVATE_KEY
+      }),
+      databaseURL: 'https://linkup-7739d.firebaseio.com'
+    })
+  }
+  return admin
+}

--- a/src/services/gateway/database.js
+++ b/src/services/gateway/database.js
@@ -1,17 +1,6 @@
-import * as admin from 'firebase-admin'
+import Administrator from './administrator'
 
 export default function Database(table) {
-  if (admin.apps.length === 0) {
-    admin.initializeApp({
-      credential: admin.credential.cert({
-        projectId: 'linkup-7739d',
-        clientEmail: 'firebase-adminsdk-7txkj@linkup-7739d.iam.gserviceaccount.com',
-        privateKey: process.env.FIREBASE_PRIVATE_KEY
-      }),
-      databaseURL: 'https://linkup-7739d.firebaseio.com'
-    })
-  }
-
-  const db = admin.database()
+  const db = Administrator().database()
   return db.ref(`/${table}`)
 }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -3,7 +3,7 @@ import Validator from 'jsonschema'
 import userSchema from './schemas/userSchema'
 import Promise from 'bluebird'
 
-export default function UserService() {
+export default function UserService(uid = null) {
   const validateUser = user => {
     const correctness = {}
     const v = new Validator.Validator()
@@ -39,9 +39,11 @@ export default function UserService() {
       return Database('users').once('value').then(snap => {
         const usersArray = []
         snap.forEach(childSnap => {
-          const user = childSnap.val()
-          user.id = childSnap.key
-          usersArray.push(user)
+          if (childSnap.key !== uid) {
+            const user = childSnap.val()
+            user.id = childSnap.key
+            usersArray.push(user)
+          }
         })
         return usersArray
       })

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -3,7 +3,7 @@ import Validator from 'jsonschema'
 import userSchema from './schemas/userSchema'
 import Promise from 'bluebird'
 
-export default function UserService(uid = null) {
+export default function UserService() {
   const validateUser = user => {
     const correctness = {}
     const v = new Validator.Validator()
@@ -35,7 +35,7 @@ export default function UserService(uid = null) {
         snap.forEach(childSnap => childSnap.val().name)
       })
     },
-    getAllUsers: () => {
+    getAllUsers: uid => {
       return Database('users').once('value').then(snap => {
         const usersArray = []
         snap.forEach(childSnap => {


### PR DESCRIPTION
Este PR introduce una autenticación en las llamadas a la API, mediante el cual es necesario que se mande el `token` del usuario como header del request.

Closes #10.