### PR TITLE
Crear endpoints para (un)linkear

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import UserService from './services/userService'
+import LinkService from './services/linkService'
 import bodyParser from 'body-parser'
 
 const app = express()
@@ -29,6 +30,16 @@ app.get('/users/:id', (request, response) => {
 
 app.get('/users', (request, response) => {
   UserService().getAllUsers().then(users => response.json(users))
+})
+
+app.put('/link/:id', (request, response) => {
+  const uid = request.get('token')
+  LinkService(uid).link(request.params.id).then(() => response.status(201).send())
+})
+
+app.put('/unlink/:id', (request, response) => {
+  const uid = request.get('token')
+  LinkService(uid).unlink(request.params.id).then(() => response.status(201).send())
 })
 
 app.listen(app.get('port'), () => {

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -1,0 +1,18 @@
+import Database from './gateway/database'
+
+export default (uid = null) => {
+  return {
+    link: userId => {
+      const linksRef = Database(`links/${uid}`)
+      return linksRef.push({
+        [userId]: true
+      })
+    },
+    unlink: userId => {
+      const linksRef = Database(`unlinks/${uid}`)
+      return linksRef.push({
+        [userId]: true
+      })
+    }
+  }
+}


### PR DESCRIPTION
Agrego endpoints de link y unlink, que generan un registro en la db, en las "tablas" `links` y `unlinks`, donde se va generando una tabla con los links y unlinks que un usuario fue generando.

Hay que ver si está bien estructurarlo así, o capaz hay alguna forma mejor (Por ejemplo, guardarlo directamente en la "tabla" de `users`).

Como dato de color, está bueno para leer: https://www.firebase.com/docs/web/guide/structuring-data.html

Closes #12 