### PR TITLE
Mock firebase and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ cache:
   directories:
     - node_modules
 
+before_script:
+  - sudo -- sh -c -e "echo '127.0.0.1	localhost.firebaseio.test' >> /etc/hosts"
+
 script:
-  - npm run lint
   - npm test
+  - npm run lint
 
 notifications:
   slack: link-up-group:CDs71nA1i9gYXueHfHghIjNe

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ cache:
   directories:
     - node_modules
 
-before_script:
-  - sudo -- sh -c -e "echo '127.0.0.1	localhost.firebaseio.test' >> /etc/hosts"
+addons:
+  hosts:
+    - localhost.firebaseio.test
 
 script:
   - npm test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,31 @@
 # backend [![Build Status](https://travis-ci.org/LinkUpFiuba/backend.svg?branch=master)](https://travis-ci.org/LinkUpFiuba/backend)
 
-## Configuración
+## Servidor
+
+### Configuración
 Para correr el servidor, es necesario tener seteada la variable de ambiente `FIREBASE_PRIVATE_KEY` con la clave privada que se encuentra en el [archivo generado](https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk?hl=es-419) por Firebase. Si no posee dicho archivo, contáctese para obtener dicha clave privada.
+
+### Cómo correrlo?
+Al utilizar `npm` es muy fácil correr el servidor. Para correrlo localmente, basta con correr:
+```
+npm start
+```
+Esto hará que con cada cambio que se haga, el servidor se restartee, lo cual es bastante útil. Si en cambio, se quiere correr el servidor para que quede "estático" (Como lo haría un servidor en producción), hay que correr el siguiente comando:
+```
+npm run build && npm run serve
+```
+
+## Testing
+Para correr los tests, es necesario poder levantar un servidor Firebase localmente. Para ello se utiliza el paquete de `firebase-server`. Un requerimiento que tiene dicho paquete es que el host en donde se levanta Firebase debe tener 2 puntos (Es decir, no se puede levantar en `127.0.0.1`, ya que tiene 3 puntos). Por ello, es necesario crear un "alias" para esto, que se corresponda con dicha restricción. Para eso, basta con correr este comando:
+
+```bash
+sudo -- sh -c -e "echo '127.0.0.1   localhost.firebaseio.test' >> /etc/hosts"
+```
+
+Luego de esto, basta con correr los tests como:
+```
+npm test
+```
 
 ## API
 _**Nota:** todos los requests que se hacen deben contener un header con 'token' como clave y el valor del token del usuario como valor_

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "nodemon src/index.js --exec babel-node",
     "build": "babel src -d dist",
     "serve": "node dist/index.js",
-    "test": "mocha --compilers js:babel-register",
+    "test": "MOCKFIREBASE_DB_URL='ws://localhost.firebaseio.test:5000' mocha --compilers js:babel-register",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -31,16 +31,22 @@
   "devDependencies": {
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
+    "ecdsa-sig-formatter": "^1.0.9",
     "eslint": "^4.5.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "firebase": "^4.3.1",
+    "firebase-server": "^0.11.0",
     "mocha": "^3.5.0",
     "nodemon": "^1.11.0",
     "request": "^2.81.0",
-    "tape": "^4.7.0"
+    "tape": "^4.7.0",
+    "websocket": "^1.0.24",
+    "websocket-driver": "^0.6.5",
+    "websocket-extensions": "^0.1.2"
   },
   "repository": {
     "type": "git",

--- a/src/services/gateway/administrator.js
+++ b/src/services/gateway/administrator.js
@@ -3,6 +3,7 @@ import * as firebase from 'firebase'
 
 export default () => {
   const TEST_URL = process.env.MOCKFIREBASE_DB_URL
+
   if (!TEST_URL) {
     if (admin.apps.length === 0) {
       admin.initializeApp({
@@ -15,14 +16,13 @@ export default () => {
       })
     }
     return admin
-  } else {
-    if (firebase.apps.length === 0) {
-      const config = {
-        apiKey: 'fake-api-key-for-testing-purposes-only',
-        databaseURL: TEST_URL
-      }
-      firebase.initializeApp(config, 'TestingEnvironment')
-    }
-    return firebase.app('TestingEnvironment')
   }
+  if (firebase.apps.length === 0) {
+    const config = {
+      apiKey: 'fake-api-key-for-testing-purposes-only',
+      databaseURL: TEST_URL
+    }
+    firebase.initializeApp(config, 'TestingEnvironment')
+  }
+  return firebase.app('TestingEnvironment')
 }

--- a/src/services/gateway/administrator.js
+++ b/src/services/gateway/administrator.js
@@ -1,15 +1,28 @@
 import * as admin from 'firebase-admin'
+import * as firebase from 'firebase'
 
 export default () => {
-  if (admin.apps.length === 0) {
-    admin.initializeApp({
-      credential: admin.credential.cert({
-        projectId: 'linkup-7739d',
-        clientEmail: 'firebase-adminsdk-7txkj@linkup-7739d.iam.gserviceaccount.com',
-        privateKey: process.env.FIREBASE_PRIVATE_KEY
-      }),
-      databaseURL: 'https://linkup-7739d.firebaseio.com'
-    })
+  const TEST_URL = process.env.MOCKFIREBASE_DB_URL
+  if (!TEST_URL) {
+    if (admin.apps.length === 0) {
+      admin.initializeApp({
+        credential: admin.credential.cert({
+          projectId: 'linkup-7739d',
+          clientEmail: 'firebase-adminsdk-7txkj@linkup-7739d.iam.gserviceaccount.com',
+          privateKey: process.env.FIREBASE_PRIVATE_KEY
+        }),
+        databaseURL: 'https://linkup-7739d.firebaseio.com'
+      })
+    }
+    return admin
+  } else {
+    if (firebase.apps.length === 0) {
+      const config = {
+        apiKey: 'fake-api-key-for-testing-purposes-only',
+        databaseURL: TEST_URL
+      }
+      firebase.initializeApp(config, 'TestingEnvironment')
+    }
+    return firebase.app('TestingEnvironment')
   }
-  return admin
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,44 @@
-import assert from 'assert'
-import { describe, it } from 'mocha'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { describe, it, before, after } from 'mocha'
+import UserService from '../src/services/userService'
+import FirebaseServer from 'firebase-server'
 
-describe('Array', () => {
-  describe('#indexOf()', () => {
-    it('should return -1 when the value is not present', () => {
-      assert.equal(-1, [1, 2, 3].indexOf(4))
+chai.use(chaiAsPromised)
+const expect = chai.expect
+
+describe('UserService', () => {
+  describe('#getAllUsers(uid)', () => {
+    let server
+    before(() => {
+      const users = {
+        users: {
+          'aUid': {
+            id: 'aUid'
+          },
+          'anotherUid': {
+            id: 'anotherUid'
+          }
+        }
+      }
+      server = new FirebaseServer(5000, 'localhost.firebaseio.test', users)
+    })
+
+    it('returns all users from database', () => {
+      return UserService().getAllUsers('someUid').then(users => {
+        expect(users.length).to.equal(2)
+      })
+    })
+
+    it('returns all users from database, except the one who is making the request', () => {
+      return UserService().getAllUsers('anotherUid').then(users => {
+        expect(users.length).to.equal(1)
+        expect(users[0].id).to.equal('aUid')
+      })
+    })
+
+    after(() => {
+      server.close(console.log('— firebase server closed -'))
     })
   })
 })


### PR DESCRIPTION
Usar un mock de Firebase para poder correr tests sin usar la base de datos de producción.

Closes #7 

### Links
https://firebase.googleblog.com/2015/04/end-to-end-testing-with-firebase-server_16.html
https://medium.com/@io.marco.valente/testing-firebase-with-mocha-locally-da7920c902f1
https://github.com/urish/firebase-server

Otra posibilidad interesante puede ser: https://www.npmjs.com/package/firebase-admin-mock