### PR TITLE
Detectar links

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,8 @@ app.post('/getToken', (request, response) => {
     .catch(error => response.json({ error: error }))
 })
 
-LinkService().detectLinks()
+// LinkService().detectLinks()
+LinkService().detectLinks2()
 
 app.listen(app.get('port'), () => {
   console.log(`Node app is running on port ${port}`)

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ app.post('/getToken', (request, response) => {
 })
 
 // LinkService().detectLinks()
-LinkService().detectLinks2()
+LinkService().detectLinks()
 
 app.listen(app.get('port'), () => {
   console.log(`Node app is running on port ${port}`)

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,6 @@ app.post('/getToken', (request, response) => {
     .catch(error => response.json({ error: error }))
 })
 
-// LinkService().detectLinks()
 LinkService().detectLinks()
 
 app.listen(app.get('port'), () => {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import Administrator from './services/gateway/administrator'
 import bodyParser from 'body-parser'
 import firebase from 'firebase'
 import firebaseService from './services/firebaseService'
+import LinkService from './services/linkService'
 
 const app = express()
 const port = process.env.PORT || 5000
@@ -52,6 +53,8 @@ app.post('/getToken', (request, response) => {
     .then(user => response.json({ user: user }))
     .catch(error => response.json({ error: error }))
 })
+
+LinkService().detectLinks()
 
 app.listen(app.get('port'), () => {
   console.log(`Node app is running on port ${port}`)

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -1,6 +1,11 @@
 import Database from './gateway/database'
 
 export default function LinkService() {
+  const checkLink = (linkingUser, linkedUser) => {
+    const linksRef = Database('links')
+    return linksRef.child(`${linkedUser}/${linkingUser}`).once('value').then(snapshot => snapshot.exists())
+  }
+
   return {
     getLinks: actualUser => {
       const linksRef = Database('links')
@@ -38,8 +43,9 @@ export default function LinkService() {
       // This works if we put a timestamp instead of a true for the links table
       linksRef.on('child_changed', link => {
         console.log('A child has changed!')
-        console.log(`Liking user: ${link.key}`)
-        let likedUsers = link.val()
+        const linkingUser = link.key
+        console.log(`Linking user: ${linkingUser}`)
+        let linkedUsers = link.val()
         // El problema que le veo a esto es que no se como se maneja firebase si entran varios changes.
         // O sea, si es posible que en el child_changed se genere cuando cambiaron 2 cosas casi simultaneas,
         // esto no funcionaria porque solo "atenderia" a la ultima. Si en cambio los eventos se "encolan"
@@ -48,8 +54,10 @@ export default function LinkService() {
         // Otra forma de solucionar esto, es tener un valor dentro de cada user que indique el ultimo
         // timestamp que proceso, y filtrar los timestamps mayores a este para procesar (y actualizarlo)
         // Order them by timestamp
-        likedUsers = Object.keys(likedUsers).sort((a, b) => likedUsers[b] - likedUsers[a])
-        console.log(`\tLiked user: ${likedUsers[0]}`)
+        linkedUsers = Object.keys(linkedUsers).sort((a, b) => linkedUsers[b] - linkedUsers[a])
+        const linkedUser = linkedUsers[0]
+        console.log(`\tLinked user: ${linkedUser}`)
+        console.log(`\tIs there a match? ${checkLink(linkingUser, linkedUser).then(value => console.log(value))}`)
       })
 
       // Listen to users that has never made a link, so the first time they will create their key in the db
@@ -57,11 +65,15 @@ export default function LinkService() {
       linksRef.on('child_added', link => {
         if (!newItems) return
         console.log('A child has been added!')
-        console.log(`Liking user: ${link.key}`)
+        const linkingUser = link.key
+        console.log(`Liking user: ${linkingUser}`)
         // Although we know there should be only one user here, we must do a forEach
+        let linkedUser
         link.forEach(child => {
-          console.log(`\tLiked user: ${child.key}`)
+          linkedUser = child.key
+          console.log(`\tLiked user: ${linkedUser}`)
         })
+        console.log(`\tIs there a match? ${checkLink(linkingUser, linkedUser).then(value => console.log(value))}`)
       })
       // This is in order not to trigger events when the server starts
       // See: https://stackoverflow.com/questions/18270995/how-to-retrieve-only-new-data

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -14,8 +14,13 @@ export default function LinkService() {
         console.log(`${newMatch ? '\tThere is a new match!' : '\tNo new match :('}`)
         if (newMatch) {
           const matchesRef = Database('matches')
-          matchesRef.child(`${linkedUser}/${linkingUser}`).set({ read: false }).then(() => {
-            return matchesRef.child(`${linkingUser}/${linkedUser}`).set({ read: false })
+          const matchesToCreate = {}
+          matchesToCreate[`${linkedUser}/${linkingUser}/read`] = false
+          matchesToCreate[`${linkingUser}/${linkedUser}/read`] = false
+          return matchesRef.update(matchesToCreate).then(() => {
+            console.log('\tMatch successfully created!')
+          }).catch(() => {
+            console.log('\tMatch could not be created :(')
           })
         }
       })
@@ -110,9 +115,7 @@ export default function LinkService() {
         const linkedUser = possibleMatch.child('linkedUser').val()
         console.log(`\tLinked user: ${linkedUser}`)
         checkLink2(linkingUser, linkedUser)
-          .then(() => {
-            possibleMatchesRef.child(possibleMatch.key).remove()
-          })
+          .then(() => possibleMatchesRef.child(possibleMatch.key).remove())
           .then(() => {
             console.log('Possible match removed!')
           })

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -42,13 +42,19 @@ export default function LinkService() {
       //   })
       // })
 
-      // Esto funciona, pero no se puede determinar cual fue el usuario al cual likeo (trae todos ¯\_(ツ)_/¯)
+      // This works if we put a timestamp instead of a true for the links table
       linksRef.on('child_changed', link => {
         console.log('A child has changed!')
         console.log(`Liking user: ${link.key}`)
-        link.forEach(child => {
-          console.log(`\tPossible liked user: ${child.key}`)
-        })
+        let likedUsers = link.val()
+        // El problema que le veo a esto es que no se como se maneja firebase si entran varios changes.
+        // O sea, si es posible que en el child_changed se genere cuando cambiaron 2 cosas casi simultaneas,
+        // esto no funcionaria porque solo "atenderia" a la ultima. Si en cambio los eventos se "encolan"
+        // haciendo que entren 2 eventos distintos con los cambios en la base hasta ese momento, esto si funca
+        // De todas formas, sigo investigando a ver si hay algo mejor para hacer.
+        // Order them by timestamp
+        likedUsers = Object.keys(likedUsers).sort((a, b) => likedUsers[b] - likedUsers[a])
+        console.log(`\tLiked user: ${likedUsers[0]}`)
       })
 
       // Listen to users that has never made a link, so the first time they will create their key in the db
@@ -63,6 +69,7 @@ export default function LinkService() {
         })
       })
       // This is in order not to trigger events when the server starts
+      // See: https://stackoverflow.com/questions/18270995/how-to-retrieve-only-new-data
       linksRef.once('value', () => {
         newItems = true
       })

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -5,10 +5,10 @@ export default function LinkService() {
     const linksRef = Database('links')
     return linksRef.child(`${linkedUser}/${linkingUser}`).once('value')
       .then(snapshot => {
-        const newMatch = snapshot.exists()
+        const isNewMatch = snapshot.exists()
         // Create push notification!
-        console.log(`${newMatch ? '\tThere is a new match!' : '\tNo new match :('}`)
-        if (newMatch) {
+        console.log(`${isNewMatch ? '\tThere is a new match!' : '\tNo new match :('}`)
+        if (isNewMatch) {
           const matchesRef = Database('matches')
           const matchesToCreate = {}
           matchesToCreate[`${linkedUser}/${linkingUser}/read`] = false

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -29,6 +29,37 @@ export default function LinkService() {
     deleteUnlinks: actualUser => {
       const unlinksRef = Database('unlinks')
       return unlinksRef.child(actualUser.Uid).remove()
+    },
+
+    detectLinks: () => {
+      console.log('Starting to detect links')
+      const linksRef = Database('links')
+      // linksRef.on('child_changed', userSnapshot => {
+      //   console.log(userSnapshot.key, userSnapshot.val())
+      //   console.log(userSnapshot.toJSON())
+      //   userSnapshot.on('child_added', itemSnapshot => {
+      //     console.log(`${itemSnapshot.val()}`)
+      //   })
+      // })
+
+      // Esto funciona, pero no se puede determinar cual fue el usuario al cual likeo (trae todos ¯\_(ツ)_/¯)
+      linksRef.on('child_changed', link => {
+        console.log('A child has changed!')
+        console.log(`Liking user: ${link.key}`)
+        link.forEach(child => {
+          console.log(`\tPossible liked user: ${child.key}`)
+        })
+      })
+
+      // No se por que esto se ejecuta cuando arranca el server tambien, pero mas alla de eso, funca
+      linksRef.on('child_added', link => {
+        console.log('A child has been added!')
+        console.log(`Liking user: ${link.key}`)
+        // Although we know there should be only one user here, we must do a forEach
+        link.forEach(child => {
+          console.log(`\tLiked user: ${child.key}`)
+        })
+      })
     }
   }
 }

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -22,6 +22,20 @@ export default function LinkService() {
       })
   }
 
+  const onChildAdded = possibleMatch => {
+    const possibleMatchesRef = Database('possibleMatches')
+    console.log('A possible match was detected!')
+    const linkingUser = possibleMatch.child('linkingUser').val()
+    console.log(`\tLinking user: ${linkingUser}`)
+    const linkedUser = possibleMatch.child('linkedUser').val()
+    console.log(`\tLinked user: ${linkedUser}`)
+    return checkLink(linkingUser, linkedUser)
+      .then(() => possibleMatchesRef.child(possibleMatch.key).remove())
+      .then(() => {
+        console.log('Possible match removed!')
+      })
+  }
+
   return {
     getLinks: actualUser => {
       const linksRef = Database('links')
@@ -57,16 +71,7 @@ export default function LinkService() {
       const possibleMatchesRef = Database('possibleMatches')
 
       possibleMatchesRef.on('child_added', possibleMatch => {
-        console.log('A possible match was detected!')
-        const linkingUser = possibleMatch.child('linkingUser').val()
-        console.log(`\tLinking user: ${linkingUser}`)
-        const linkedUser = possibleMatch.child('linkedUser').val()
-        console.log(`\tLinked user: ${linkedUser}`)
-        checkLink(linkingUser, linkedUser)
-          .then(() => possibleMatchesRef.child(possibleMatch.key).remove())
-          .then(() => {
-            console.log('Possible match removed!')
-          })
+        onChildAdded(possibleMatch)
       })
     }
   }

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -34,13 +34,6 @@ export default function LinkService() {
     detectLinks: () => {
       console.log('Starting to detect links')
       const linksRef = Database('links')
-      // linksRef.on('child_changed', userSnapshot => {
-      //   console.log(userSnapshot.key, userSnapshot.val())
-      //   console.log(userSnapshot.toJSON())
-      //   userSnapshot.on('child_added', itemSnapshot => {
-      //     console.log(`${itemSnapshot.val()}`)
-      //   })
-      // })
 
       // This works if we put a timestamp instead of a true for the links table
       linksRef.on('child_changed', link => {
@@ -52,6 +45,8 @@ export default function LinkService() {
         // esto no funcionaria porque solo "atenderia" a la ultima. Si en cambio los eventos se "encolan"
         // haciendo que entren 2 eventos distintos con los cambios en la base hasta ese momento, esto si funca
         // De todas formas, sigo investigando a ver si hay algo mejor para hacer.
+        // Otra forma de solucionar esto, es tener un valor dentro de cada user que indique el ultimo
+        // timestamp que proceso, y filtrar los timestamps mayores a este para procesar (y actualizarlo)
         // Order them by timestamp
         likedUsers = Object.keys(likedUsers).sort((a, b) => likedUsers[b] - likedUsers[a])
         console.log(`\tLiked user: ${likedUsers[0]}`)

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -51,14 +51,20 @@ export default function LinkService() {
         })
       })
 
-      // No se por que esto se ejecuta cuando arranca el server tambien, pero mas alla de eso, funca
+      // Listen to users that has never made a link, so the first time they will create their key in the db
+      let newItems = false
       linksRef.on('child_added', link => {
+        if (!newItems) return
         console.log('A child has been added!')
         console.log(`Liking user: ${link.key}`)
         // Although we know there should be only one user here, we must do a forEach
         link.forEach(child => {
           console.log(`\tLiked user: ${child.key}`)
         })
+      })
+      // This is in order not to trigger events when the server starts
+      linksRef.once('value', () => {
+        newItems = true
       })
     }
   }

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -66,6 +66,11 @@ export default function LinkService() {
       return unlinksRef.child(actualUser.Uid).remove()
     },
 
+    // This is just for test purposes
+    onChildAdded: possibleMatch => {
+      return onChildAdded(possibleMatch)
+    },
+
     detectLinks: () => {
       console.log('Starting to detect links')
       const possibleMatchesRef = Database('possibleMatches')

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -6,6 +6,21 @@ export default function LinkService() {
     return linksRef.child(`${linkedUser}/${linkingUser}`).once('value').then(snapshot => snapshot.exists())
   }
 
+  const checkLink2 = (linkingUser, linkedUser) => {
+    const linksRef = Database('links')
+    return linksRef.child(`${linkedUser}/${linkingUser}`).once('value')
+      .then(snapshot => {
+        const newMatch = snapshot.exists()
+        console.log(`${newMatch ? '\tThere is a new match!' : '\tNo new match :('}`)
+        if (newMatch) {
+          const matchesRef = Database('matches')
+          matchesRef.child(`${linkedUser}/${linkingUser}`).set({ read: false }).then(() => {
+            return matchesRef.child(`${linkingUser}/${linkedUser}`).set({ read: false })
+          })
+        }
+      })
+  }
+
   return {
     getLinks: actualUser => {
       const linksRef = Database('links')
@@ -94,14 +109,7 @@ export default function LinkService() {
         console.log(`\tLinking user: ${linkingUser}`)
         const linkedUser = possibleMatch.child('linkedUser').val()
         console.log(`\tLinked user: ${linkedUser}`)
-        checkLink(linkingUser, linkedUser)
-          .then(newMatch => {
-            if (newMatch) {
-              const matchesRef = Database('matches')
-              matchesRef.child(`${linkedUser}/${linkingUser}`)
-            }
-            console.log(`${newMatch ? '\tThere is a new match!' : '\tNo new match :('}`)
-          })
+        checkLink2(linkingUser, linkedUser)
           .then(() => {
             possibleMatchesRef.child(possibleMatch.key).remove()
           })

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -3,14 +3,10 @@ import Database from './gateway/database'
 export default function LinkService() {
   const checkLink = (linkingUser, linkedUser) => {
     const linksRef = Database('links')
-    return linksRef.child(`${linkedUser}/${linkingUser}`).once('value').then(snapshot => snapshot.exists())
-  }
-
-  const checkLink2 = (linkingUser, linkedUser) => {
-    const linksRef = Database('links')
     return linksRef.child(`${linkedUser}/${linkingUser}`).once('value')
       .then(snapshot => {
         const newMatch = snapshot.exists()
+        // Create push notification!
         console.log(`${newMatch ? '\tThere is a new match!' : '\tNo new match :('}`)
         if (newMatch) {
           const matchesRef = Database('matches')
@@ -58,63 +54,15 @@ export default function LinkService() {
 
     detectLinks: () => {
       console.log('Starting to detect links')
-      const linksRef = Database('links')
-
-      // This works if we put a timestamp instead of a true for the links table
-      linksRef.on('child_changed', link => {
-        console.log('A child has changed!')
-        const linkingUser = link.key
-        console.log(`Linking user: ${linkingUser}`)
-        let linkedUsers = link.val()
-        // El problema que le veo a esto es que no se como se maneja firebase si entran varios changes.
-        // O sea, si es posible que en el child_changed se genere cuando cambiaron 2 cosas casi simultaneas,
-        // esto no funcionaria porque solo "atenderia" a la ultima. Si en cambio los eventos se "encolan"
-        // haciendo que entren 2 eventos distintos con los cambios en la base hasta ese momento, esto si funca
-        // De todas formas, sigo investigando a ver si hay algo mejor para hacer.
-        // Otra forma de solucionar esto, es tener un valor dentro de cada user que indique el ultimo
-        // timestamp que proceso, y filtrar los timestamps mayores a este para procesar (y actualizarlo)
-        // Order them by timestamp
-        linkedUsers = Object.keys(linkedUsers).sort((a, b) => linkedUsers[b] - linkedUsers[a])
-        const linkedUser = linkedUsers[0]
-        console.log(`\tLinked user: ${linkedUser}`)
-        checkLink(linkingUser, linkedUser)
-          .then(newMatch => console.log(`${newMatch ? '\tThere is a new match!' : '\tNo new match :('}`))
-      })
-
-      // Listen to users that has never made a link, so the first time they will create their key in the db
-      let newItems = false
-      linksRef.on('child_added', link => {
-        if (!newItems) return
-        console.log('A child has been added!')
-        const linkingUser = link.key
-        console.log(`Liking user: ${linkingUser}`)
-        // Although we know there should be only one user here, we must do a forEach
-        let linkedUser
-        link.forEach(child => {
-          linkedUser = child.key
-          console.log(`\tLiked user: ${linkedUser}`)
-        })
-        checkLink(linkingUser, linkedUser)
-          .then(newMatch => console.log(`${newMatch ? '\tThere is a new match!' : '\tNo new match :('}`))
-      })
-      // This is in order not to trigger events when the server starts
-      // See: https://stackoverflow.com/questions/18270995/how-to-retrieve-only-new-data
-      linksRef.once('value', () => {
-        newItems = true
-      })
-    },
-
-    detectLinks2: () => {
-      console.log('Starting to detect links2')
       const possibleMatchesRef = Database('possibleMatches')
 
       possibleMatchesRef.on('child_added', possibleMatch => {
-        console.log('A child has been added!')
+        console.log('A possible match was detected!')
         const linkingUser = possibleMatch.child('linkingUser').val()
         console.log(`\tLinking user: ${linkingUser}`)
         const linkedUser = possibleMatch.child('linkedUser').val()
         console.log(`\tLinked user: ${linkedUser}`)
-        checkLink2(linkingUser, linkedUser)
+        checkLink(linkingUser, linkedUser)
           .then(() => possibleMatchesRef.child(possibleMatch.key).remove())
           .then(() => {
             console.log('Possible match removed!')

--- a/test/services/linkService.test.js
+++ b/test/services/linkService.test.js
@@ -91,4 +91,106 @@ describe('LinkService', () => {
       })
     })
   })
+
+  describe('#detectLinks()', () => {
+    const user1 = new User().get()
+    const user2 = new User().get()
+
+    describe('when only one user has linked', () => {
+      before(() => {
+        const links = {
+          [user1.Uid]: {
+            [user2.Uid]: true
+          }
+        }
+        const linksRef = Database('links')
+        linksRef.set(links)
+      })
+
+      it('does not create the match', () => {
+        const possibleMatch = {
+          aUniqueId: {
+            linkingUser: user1.Uid,
+            linkedUser: user2.Uid
+          }
+        }
+        const possibleMatchesRef = Database('possibleMatches')
+        const matchesRef = Database('matches')
+        possibleMatchesRef.set(possibleMatch)
+        return matchesRef.child(`aUniqueId/${user1.Uid}`).once('value').then(match => {
+          expect(match.exists()).to.be.false
+          expect(match.val()).to.be.null
+        })
+      })
+
+      // // This test should be also use when both users have linked
+      // it('removes the possible match', () => {
+      //   const possibleMatch = {
+      //     aUniqueId: {
+      //       linkingUser: user1.Uid,
+      //       linkedUser: user2.Uid
+      //     }
+      //   }
+      //   const possibleMatchesRef = Database('possibleMatches')
+      //   possibleMatchesRef.set(possibleMatch)
+      //   //   .then(() => {
+      //   //     return possibleMatchesRef.once('child_removed').then(possibleMatch => {
+      //   //       console.log('Child removed!')
+      //   //       expect(true).to.be.false
+      //   //       // expect(possibleMatch.key).to.equal('aUniqueId')
+      //   //     })
+      //   //   })
+      //
+      //   // Not working
+      //   // return possibleMatchesRef.once('child_removed').then(possibleMatch => {
+      //   //   console.log('Child removed!')
+      //   //   expect(possibleMatch.key).to.equal('aUniqueId')
+      //   // })
+      //
+      //   // Not working
+      //   // return setTimeout(() => {
+      //   //   console.log('In timeout')
+      //   //   return possibleMatchesRef.once('value').then(possibleMatches => {
+      //   //     expect(possibleMatches.val()).to.be.null
+      //   //   })
+      //   // }, 5000)
+      //
+      //   // Working but needs to wait until it's removed to pass the expect
+      //   // return possibleMatchesRef.once('value').then(possibleMatches => {
+      //   //   expect(possibleMatches.val()).to.be.null
+      //   // })
+      // })
+    })
+
+    describe('when both users have linked each other', () => {
+      before(() => {
+        const links = {
+          [user1.Uid]: {
+            [user2.Uid]: true
+          },
+          [user2.Uid]: {
+            [user1.Uid]: true
+          }
+        }
+        const linksRef = Database('links')
+        linksRef.set(links)
+      })
+
+      // it('creates the match', () => {
+      //   const possibleMatch = {
+      //     aUniqueId: {
+      //       linkingUser: user1.Uid,
+      //       linkedUser: user2.Uid
+      //     }
+      //   }
+      //   const possibleMatchesRef = Database('possibleMatches')
+      //   const matchesRef = Database('matches')
+      //   return possibleMatchesRef.set(possibleMatch).then(() => {
+      //     return matchesRef.once('child_added').then(matches => {
+      //       expect(matches.val()).not.to.be.null
+      //     })
+      //   })
+      // })
+    })
+  })
 })

--- a/test/services/linkService.test.js
+++ b/test/services/linkService.test.js
@@ -132,16 +132,6 @@ describe('LinkService', () => {
         })
       })
 
-      // This test is only to ensure that the each time the possible match is created. Maybe it could be removed
-      it('the possible match is already created', () => {
-        const possibleMatchesRef = Database('possibleMatches')
-
-        return possibleMatchesRef.once('value').then(possibleMatches => {
-          expect(possibleMatches.exists()).to.be.true
-          expect(possibleMatches.val()).not.to.be.null
-        })
-      })
-
       // This test should be also use when both users have linked
       it('removes the possible match', () => {
         const possibleMatchesRef = Database('possibleMatches')

--- a/test/services/linkService.test.js
+++ b/test/services/linkService.test.js
@@ -132,7 +132,6 @@ describe('LinkService', () => {
         })
       })
 
-      // This test should be also use when both users have linked
       it('removes the possible match', () => {
         const possibleMatchesRef = Database('possibleMatches')
 


### PR DESCRIPTION
La idea es tener escuchando a Firebase sobre donde se van a crear los links. Con @AndresOtero estuvimos barajando 2 opciones:
- La primera (que se corresponde con los métodos `detectLinks` y `checkLink`) es estar escuchando sobre la tabla de `links`. Esto tiene algunas complejidades:
  * Por un lado, hay que escuchar 2 eventos: `child_added` (Para usuarios que nunca hicieron un link) y `child_changed` (Para los que ya tenían hechos).
  * Por otro lado, el evento `child_added` en este caso requiere un pequeño hack para que, al comenzar el servidor, no quiera fijarse en hijos que ya existían antes de comenzar (Utilizando la variable `newItems`). Esto no es tan grave.
  * En cuanto al evento `child_changed`, el problema viene dado porque cuando se dispara el evento, se sabe cuál fue el child que cambió (Para nuestro caso sería qué usuario dijo que quería linkear con alguien), pero a quién le dio que quería linkear (Ya que puede tener varios que ya fueron procesados). Esto lo solucioné haciendo que en vez de guardar un `true` como valor, se guarde el timestamp. Luego, se ordenan las claves (Es decir los usuarios a los que linkeo) según el timestamp, obteniendo así el último usuario con el que quiso linkear. Esto tiene un problema extra que cito del código:
> El problema que le veo a esto es que no se como se maneja firebase si entran varios changes. O sea, si es posible que en el child_changed se genere cuando cambiaron 2 cosas casi simultaneas, esto no funcionaria porque solo "atenderia" a la ultima. Si en cambio los eventos se "encolan" haciendo que entren 2 eventos distintos con los cambios en la base hasta ese momento, esto si funca.
> Otra forma de solucionar esto, es tener un valor dentro de cada user que indique el ultimo timestamp que proceso, y filtrar los timestamps mayores a este para procesar (y actualizarlo)
- Por todo esto es que surgió la segunda opción. Esto es que @AndresOtero cree en la base de datos en la tabla `links` el link correspondiente, y además cree una entrada en otra tabla llamada `posibleMatches` con la estructura:
```
possibleMatches: {
  "unIdGeneradoEnElPush": {
    "linkingUser": unUid,
    "linkedUser": otroUid
  }
}
```
Esta última sería la tabla que se escucharía desde el backend (ver métodos `detectLinks2` y `checkLink2`), para luego crear en la tabla `matches` las entradas correspondientes para ambos usuarios y luego de eso, sacar el `possibleMatch` que se acaba de procesar. Esto tiene la ventaja de que no se necesita ninguno de los hacks ni tiene ninguno de los problemas mencionados en la primera opción.

@fedebrasburg pido opinión sobre todo esto!