### PR TITLE
Exclude blocked users from matching

### DIFF
--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -568,6 +568,56 @@ describe('UserService', () => {
       })
     })
 
+    describe('Test for blocking filter', () => {
+      before(() => {
+        Database('unlinks').set({})
+        Database('links').set({})
+        const users = {
+          [maleForFriends.Uid]: maleForFriends,
+          [femaleForFriends.Uid]: femaleForFriends
+        }
+        const usersRef = Database('users')
+        usersRef.set(users)
+      })
+
+      describe('when they are not blocked each other', () => {
+        before(() => {
+          const blocksRef = Database('blocks')
+          blocksRef.set({})
+        })
+
+        it('they can be found each other', () => {
+          return UserService().getPosibleLinks(maleForFriends.Uid).then(users => {
+            expect(users.length).to.equal(1)
+            expect(users[0].Uid).to.equal(femaleForFriends.Uid)
+          })
+        })
+      })
+
+      describe('when one of the blocked the other', () => {
+        before(() => {
+          const blocksRef = Database('blocks')
+          blocksRef.set({
+            [maleForFriends.Uid]: {
+              [femaleForFriends.Uid]: true
+            }
+          })
+        })
+
+        it('the blocking user cannot find the blocked user', () => {
+          return UserService().getPosibleLinks(maleForFriends.Uid).then(users => {
+            expect(users.length).to.equal(0)
+          })
+        })
+
+        it('the blocked user cannot find the blocking user', () => {
+          return UserService().getPosibleLinks(femaleForFriends.Uid).then(users => {
+            expect(users.length).to.equal(0)
+          })
+        })
+      })
+    })
+
     describe('Test for matching algorithm', () => {
       before(() => {
         Database('unlinks').set({})

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -580,7 +580,7 @@ describe('UserService', () => {
         usersRef.set(users)
       })
 
-      describe('when they are not blocked each other', () => {
+      describe('when they have not blocked each other', () => {
         before(() => {
           const blocksRef = Database('blocks')
           blocksRef.set({})
@@ -594,7 +594,7 @@ describe('UserService', () => {
         })
       })
 
-      describe('when one of the blocked the other', () => {
+      describe('when one of them blocked the other', () => {
         before(() => {
           const blocksRef = Database('blocks')
           blocksRef.set({


### PR DESCRIPTION
La idea es excluir de los candidatos a los usuarios que bloquie, y también excluir al usuario que bloqueó del bloqueado.

No estoy especialmente orgulloso de cómo terminó funcionando, pero bueno. La idea era meterlo dentro del `validateFilters`, pero fue realmente complejo intentarlo y no llegué a nada.