### PR TITLE
Prioritize by link situation

### DIFF
--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -95,7 +95,7 @@ export default function LinkService() {
         return linksRef.child(`${user.Uid}/${actualUser.Uid}`).once('value').then(link => {
           if (unlink.exists()) return UNLINK
           if (link.exists()) {
-            if (link.val()) {
+            if (link.val() === 'superlink') {
               return SUPERLINK
             }
             return LINK

--- a/src/services/linkService.js
+++ b/src/services/linkService.js
@@ -1,6 +1,11 @@
 import Database from './gateway/database'
 import { PushNotificationService } from './pushNotificationService'
 
+export const SUPERLINK = 100
+export const LINK = 50
+export const NO_LINK = 20
+export const UNLINK = 0
+
 export default function LinkService() {
   const checkLink = (linkingUser, linkedUser) => {
     const linksRef = Database('links')
@@ -79,6 +84,24 @@ export default function LinkService() {
 
       possibleMatchesRef.on('child_added', possibleMatch => {
         onChildAdded(possibleMatch)
+      })
+    },
+
+    getLinkBetween: (actualUser, user) => {
+      const unlinksRef = Database('unlinks')
+      const linksRef = Database('links')
+
+      return unlinksRef.child(`${user.Uid}/${actualUser.Uid}`).once('value').then(unlink => {
+        return linksRef.child(`${user.Uid}/${actualUser.Uid}`).once('value').then(link => {
+          if (unlink.exists()) return UNLINK
+          if (link.exists()) {
+            if (link.val()) {
+              return SUPERLINK
+            }
+            return LINK
+          }
+          return NO_LINK
+        })
       })
     }
   }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -7,6 +7,10 @@ import LinkService from './linkService'
 import InterestsService from './interestsService'
 import DisableUserService from './disableUserService'
 
+export const DISTANCE_WEIGHT = 0.54
+export const INTERESTS_WEIGHT = 0.36
+export const LINK_SITUATION_WEIGHT = 0.1
+
 export default function UserService() {
   const FRIENDS = 'friends'
   const MALE = 'male'
@@ -16,8 +20,6 @@ export default function UserService() {
   const B = 1
   const C = 12.5
   const D = -12.5
-  const DISTANCE_WEIGHT = 0.6
-  const INTERESTS_WEIGHT = 0.4
 
   const validateUser = user => {
     const correctness = {}
@@ -80,27 +82,45 @@ export default function UserService() {
   }
 
   const calculateMatchingScore = (user, actualUser) => {
-    const commonInterests = InterestsService().getCommonInterests(user.likesList, actualUser.likesList)
-    // We include  common interests in the user in order to show it in the frontend
-    user.commonInterests = commonInterests
-    // The idea of the algorithm is to have a maximum of 100 and a minimum of 0. The distance behaves like
-    // a 1/x function, so that less distance goes with a better score. All the constants are given to have
-    // an smoother function with the corresponding max and min. On the other hand, we care about the
-    // interests as a linear function, with a max of 10 interests in common.
-    // After that, we weight the scores with a defined value.
-    // See more in: https://docs.google.com/document/d/1N0W029of2x8JeM8JIxyO0bAZbtZqgAAB5I9FQVF01v8
-    const distanceScore = (A / ((user.distance / B) + C)) + D
-    const interestsScore = Math.min(commonInterests.length * 10, 100)
-    return DISTANCE_WEIGHT * distanceScore + INTERESTS_WEIGHT * interestsScore
+    return LinkService().getLinkBetween(actualUser, user).then(linkSituationScore => {
+      const commonInterests = InterestsService().getCommonInterests(user.likesList, actualUser.likesList)
+      // We include common interests in the user in order to show it in the frontend
+      user.commonInterests = commonInterests
+      // The idea of the algorithm is to have a maximum of 100 and a minimum of 0. The distance behaves like
+      // a 1/x function, so that less distance goes with a better score. All the constants are given to have
+      // an smoother function with the corresponding max and min. On the other hand, we care about the
+      // interests as a linear function, with a max of 10 interests in common. In addition, we also give some
+      // prioritization when there's a superlink, a link or an unlink (or even if they haven't link at all).
+      // After that, we weight the scores with a defined value.
+      // See more in: https://docs.google.com/document/d/1N0W029of2x8JeM8JIxyO0bAZbtZqgAAB5I9FQVF01v8
+      const distanceScore = (A / ((user.distance / B) + C)) + D
+      const interestsScore = Math.min(commonInterests.length * 10, 100)
+      return DISTANCE_WEIGHT * distanceScore +
+             INTERESTS_WEIGHT * interestsScore +
+             LINK_SITUATION_WEIGHT * linkSituationScore
+    })
+  }
+
+  const addMatchingScoreTo = (users, actualUser) => {
+    const usersArray = []
+    const promisesArray = []
+    users.forEach(user => {
+      promisesArray.push(
+        calculateMatchingScore(user, actualUser).then(matchingScore => {
+          user.matchingScore = matchingScore
+          usersArray.push(user)
+        })
+      )
+    })
+    return Promise.all(promisesArray).then(() => usersArray)
   }
 
   const orderByMatchingAlgorithm = (users, actualUser) => {
-    users.map(user => {
-      user.matchingScore = calculateMatchingScore(user, actualUser)
+    return addMatchingScoreTo(users, actualUser).then(usersWithMatchingScore => {
+      // Descending order
+      usersWithMatchingScore.sort((user1, user2) => user2.matchingScore - user1.matchingScore)
+      return usersWithMatchingScore
     })
-    // Descending order
-    users.sort((user1, user2) => user2.matchingScore - user1.matchingScore)
-    return users
   }
 
   const getSexualPosibleMatches = (ref, actualUser, search) => {
@@ -224,7 +244,9 @@ export default function UserService() {
           return getFriendPosibleMatches(ref, actualUser)
         })
         .then(users => {
-          const orderedUsers = orderByMatchingAlgorithm(users, actualUser)
+          return orderByMatchingAlgorithm(users, actualUser)
+        })
+        .then(orderedUsers => {
           return orderedUsers.slice(0, USERS_PER_REQUEST)
         })
     }

--- a/test/services/linkService.test.js
+++ b/test/services/linkService.test.js
@@ -108,7 +108,7 @@ describe('LinkService', () => {
       before(() => {
         const links = {
           [linkingUser.Uid]: {
-            [linkedUser.Uid]: true
+            [linkedUser.Uid]: 'normal'
           }
         }
         const linksRef = Database('links')
@@ -158,10 +158,10 @@ describe('LinkService', () => {
       before(() => {
         const links = {
           [linkingUser.Uid]: {
-            [linkedUser.Uid]: true
+            [linkedUser.Uid]: 'normal'
           },
           [linkedUser.Uid]: {
-            [linkingUser.Uid]: true
+            [linkingUser.Uid]: 'normal'
           }
         }
         const linksRef = Database('links')
@@ -237,7 +237,7 @@ describe('LinkService', () => {
       before(() => {
         const links = {
           [maleForFriends.Uid]: {
-            [femaleForFriends.Uid]: false
+            [femaleForFriends.Uid]: 'normal'
           }
         }
         unlinksRef.set({})
@@ -255,7 +255,7 @@ describe('LinkService', () => {
       before(() => {
         const links = {
           [maleForFriends.Uid]: {
-            [femaleForFriends.Uid]: true
+            [femaleForFriends.Uid]: 'superlink'
           }
         }
         unlinksRef.set({})

--- a/test/services/linkService.test.js
+++ b/test/services/linkService.test.js
@@ -1,7 +1,7 @@
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { describe, it, before, beforeEach } from 'mocha'
-import LinkService from '../../src/services/linkService'
+import LinkService, { SUPERLINK, LINK, NO_LINK, UNLINK } from '../../src/services/linkService'
 import { User } from '../factories/usersFactory'
 import Database from '../../src/services/gateway/database'
 
@@ -204,6 +204,80 @@ describe('LinkService', () => {
               expect(possibleMatches.val()).to.be.null
             })
           })
+        })
+      })
+    })
+  })
+
+  describe('#getLinkBetween', () => {
+    const maleForFriends = new User().male().likesFriends().get()
+    const femaleForFriends = new User().female().likesFriends().get()
+    const linksRef = Database('links')
+    const unlinksRef = Database('unlinks')
+
+    describe('when one user has unlinked the other', () => {
+      before(() => {
+        const unlinks = {
+          [maleForFriends.Uid]: {
+            [femaleForFriends.Uid]: true
+          }
+        }
+        unlinksRef.set(unlinks)
+        linksRef.set({})
+      })
+
+      it('it returns UNLINK', () => {
+        return LinkService().getLinkBetween(femaleForFriends, maleForFriends).then(linkSituation => {
+          expect(linkSituation).to.equal(UNLINK)
+        })
+      })
+    })
+
+    describe('when one user has linked the other', () => {
+      before(() => {
+        const links = {
+          [maleForFriends.Uid]: {
+            [femaleForFriends.Uid]: false
+          }
+        }
+        unlinksRef.set({})
+        linksRef.set(links)
+      })
+
+      it('it returns LINK', () => {
+        return LinkService().getLinkBetween(femaleForFriends, maleForFriends).then(linkSituation => {
+          expect(linkSituation).to.equal(LINK)
+        })
+      })
+    })
+
+    describe('when one user has superlinked the other', () => {
+      before(() => {
+        const links = {
+          [maleForFriends.Uid]: {
+            [femaleForFriends.Uid]: true
+          }
+        }
+        unlinksRef.set({})
+        linksRef.set(links)
+      })
+
+      it('it returns SUPERLINK', () => {
+        return LinkService().getLinkBetween(femaleForFriends, maleForFriends).then(linkSituation => {
+          expect(linkSituation).to.equal(SUPERLINK)
+        })
+      })
+    })
+
+    describe('when one user has not linked nor unlinked the other', () => {
+      before(() => {
+        unlinksRef.set({})
+        linksRef.set({})
+      })
+
+      it('it returns NO_LINK', () => {
+        return LinkService().getLinkBetween(femaleForFriends, maleForFriends).then(linkSituation => {
+          expect(linkSituation).to.equal(NO_LINK)
         })
       })
     })

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -1,11 +1,15 @@
-
 /* eslint-disable max-len */
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { describe, it, before } from 'mocha'
-import UserService from '../../src/services/userService'
+import UserService, {
+  DISTANCE_WEIGHT,
+  INTERESTS_WEIGHT,
+  LINK_SITUATION_WEIGHT
+} from '../../src/services/userService'
 import Database from '../../src/services/gateway/database'
 import { User, Interests } from '../factories/usersFactory'
+import { NO_LINK } from '../../src/services/linkService'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -710,8 +714,8 @@ describe('UserService', () => {
             [femaleForMaleNearMale.Uid]: femaleForMaleNearMale,
             [femaleForMaleNearMaleButFar.Uid]: femaleForMaleNearMaleButFar
           }
-          const ref = Database('users')
-          ref.set(users)
+          const usersRef = Database('users')
+          usersRef.set(users)
         })
 
         it('orders by distance', () => {
@@ -727,13 +731,13 @@ describe('UserService', () => {
 
         it('the user in the same spot has the best score', () => {
           return UserService().getPosibleLinks(maleForFemaleInSomePosition.Uid).then(users => {
-            expect(users[0].matchingScore).to.equal(60)
+            expect(users[0].matchingScore).to.equal(DISTANCE_WEIGHT * 100 + LINK_SITUATION_WEIGHT * NO_LINK)
           })
         })
 
         it('the furthest user has the worst score', () => {
           return UserService().getPosibleLinks(maleForFemaleInSomePosition.Uid).then(users => {
-            expect(users[4].matchingScore).to.equal(0)
+            expect(users[4].matchingScore).to.equal(DISTANCE_WEIGHT * 0 + LINK_SITUATION_WEIGHT * NO_LINK)
           })
         })
 
@@ -773,13 +777,13 @@ describe('UserService', () => {
 
         it('user with 11 interests in common has the best score', () => {
           return UserService().getPosibleLinks(maleForFemaleWithManyInterests.Uid).then(users => {
-            expect(users[0].matchingScore).to.equal(0.4 * 10 * 10)
+            expect(users[0].matchingScore).to.equal(INTERESTS_WEIGHT * 10 * 10 + LINK_SITUATION_WEIGHT * NO_LINK)
           })
         })
 
         it('user with four interests in common has the correct score', () => {
           return UserService().getPosibleLinks(maleForFemaleWithManyInterests.Uid).then(users => {
-            expect(users[2].matchingScore).to.equal(0.4 * 4 * 10)
+            expect(users[2].matchingScore).to.equal(INTERESTS_WEIGHT * 4 * 10 + LINK_SITUATION_WEIGHT * NO_LINK)
           })
         })
 

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -438,10 +438,10 @@ describe('UserService', () => {
           }
           const links = {
             [maleForFriends.Uid]: {
-              [femaleForFriends.Uid]: true
+              [femaleForFriends.Uid]: 'normal'
             },
             [femaleForFriends.Uid]: {
-              [maleForFriends.Uid]: true
+              [maleForFriends.Uid]: 'normal'
             }
           }
           Database('users').set(users)
@@ -462,7 +462,7 @@ describe('UserService', () => {
           }
           const links = {
             [maleForFriends.Uid]: {
-              [femaleForFriends.Uid]: true
+              [femaleForFriends.Uid]: 'normal'
             }
           }
           Database('users').set(users)
@@ -484,10 +484,10 @@ describe('UserService', () => {
           }
           const links = {
             [maleForFriends.Uid]: {
-              [femaleForFriends.Uid]: true
+              [femaleForFriends.Uid]: 'normal'
             },
             [femaleForFriends.Uid]: {
-              [maleForFriends.Uid]: true
+              [maleForFriends.Uid]: 'normal'
             }
           }
           Database('users').set(users)
@@ -511,16 +511,16 @@ describe('UserService', () => {
           }
           const links = {
             [maleForFriends.Uid]: {
-              [femaleForFriends.Uid]: true,
-              [maleForFriends2.Uid]: true
+              [femaleForFriends.Uid]: 'normal',
+              [maleForFriends2.Uid]: 'normal'
             },
             [femaleForFriends.Uid]: {
-              [maleForFriends.Uid]: true,
-              [maleForFriends2.Uid]: true
+              [maleForFriends.Uid]: 'normal',
+              [maleForFriends2.Uid]: 'normal'
             },
             [maleForFriends2.Uid]: {
-              [maleForFriends.Uid]: true,
-              [femaleForFriends.Uid]: true
+              [maleForFriends.Uid]: 'normal',
+              [femaleForFriends.Uid]: 'normal'
             }
           }
           Database('users').set(users)
@@ -844,10 +844,10 @@ describe('UserService', () => {
 
           const links = {
             [lastFreeUserForFriends.Uid]: {
-              [maleForFriendsAt100km.Uid]: false
+              [maleForFriendsAt100km.Uid]: 'normal'
             },
             [anotherFreeUserForFriends.Uid]: {
-              [maleForFriendsAt100km.Uid]: true
+              [maleForFriendsAt100km.Uid]: 'superlink'
             }
           }
           const linksRef = Database('links')


### PR DESCRIPTION
La idea es priorizar por si el candidato dio un superlink, un link, un unlink o bien no hizo nada aún. Para una mayor documentación se puede ver [este documento](https://docs.google.com/document/d/1N0W029of2x8JeM8JIxyO0bAZbtZqgAAB5I9FQVF01v8/edit#).

Básicamente, se da un peso de 0.1 para las situaciones de link. Esta ponderación será multiplicada por 100 en caso de un superlink, por 50 en caso de un link, por 20 en caso de no haber hecho nada aún y por 0 en caso de que el candidato haya decidido unlinkear con el usuario.

_Nota: Todavía resta definir cómo se va a modelar el superlink en la base de datos. Por el momento se asumió que, dentro de la tabla de `links`, si el valor es `true` es un superlink y si es `false` es un `link` normal_