### PR TITLE
Complaints reports endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Devuelve todas las denuncias de todos los usuarios.
 #### `GET` - `/complaints/<id>`
 Devuelve las denuncias para el usuario `id`.
 
-#### `GET` - `/complaintss/type`
+#### `GET` - `/analytics/complaints/type`
 Devuelve la cantidad de denuncias de cada tipo. Se pueden especificar los _query parameters_ `startDate` y `endDate` para restringir las fechas. Estos parámetros deben seguir el formato `YYYY-MM`.
 
-#### `GET` - `/complaintss/disabled`
+#### `GET` - `/analytics/complaints/disabled`
 Devuelve la cantidad de denuncias de un tipo especificado mediante el _query parameter_ `type`. Éste debe ser un tipo válido; en caso contrario no devolverá nada. 
 
 #### `POST` - `/users/<id>/disable`

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Devuelve todas las denuncias de todos los usuarios.
 #### `GET` - `/complaints/<id>`
 Devuelve las denuncias para el usuario `id`.
 
+#### `GET` - `/complaintss/type`
+Devuelve la cantidad de denuncias de cada tipo. Se pueden especificar los _query parameters_ `startDate` y `endDate` para restringir las fechas. Estos parámetros deben seguir el formato `YYYY-MM`.
+
 #### `POST` - `/users/<id>/disable`
 Deshabilita al usuario `id` debido a las denuncias recibidas.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Devuelve las denuncias para el usuario `id`.
 #### `GET` - `/complaintss/type`
 Devuelve la cantidad de denuncias de cada tipo. Se pueden especificar los _query parameters_ `startDate` y `endDate` para restringir las fechas. Estos parámetros deben seguir el formato `YYYY-MM`.
 
+#### `GET` - `/complaintss/disabled`
+Devuelve la cantidad de denuncias de un tipo especificado mediante el _query parameter_ `type`. Éste debe ser un tipo válido; en caso contrario no devolverá nada. 
+
 #### `POST` - `/users/<id>/disable`
 Deshabilita al usuario `id` debido a las denuncias recibidas.
 

--- a/src/index.js
+++ b/src/index.js
@@ -105,10 +105,19 @@ app.get('/complaints/:userUid', (request, response) => {
     })
 })
 
+// TODO: Hay un tema aca que /complaints/type lo interpreta como el get a /complaints/:userUid, asique hay
+// que buscar otra URL
 app.get('/complaintss/type', (request, response) => {
   response.header('Access-Control-Allow-Origin', '*')
   ComplaintService().getComplaintsByType(request.query.startDate, request.query.endDate)
     .then(complaints => response.json(complaints))
+})
+
+// TODO: Idem endpoint anterior
+app.get('/complaintss/disabled', (request, response) => {
+  response.header('Access-Control-Allow-Origin', '*')
+  ComplaintService().getDisabledUsersForType(request.query.type)
+    .then(usersWithComplaints => response.json(usersWithComplaints))
 })
 
 app.post('/users/:userUid/disable', (request, response) => {

--- a/src/index.js
+++ b/src/index.js
@@ -58,11 +58,6 @@ app.post('/ads/:adUid/disable', (request, response) => {
   AdsService().disableAd(request.params.adUid).then(() => response.send())
 })
 
-app.get('/complaints', (request, response) => {
-  response.header('Access-Control-Allow-Origin', '*')
-  ComplaintService().getComplaintsCountForUsers().then(complaints => response.json(complaints))
-})
-
 app.post('/ads', (request, response) => {
   response.header('Access-Control-Allow-Origin', '*')
   const ad = request.body
@@ -77,11 +72,6 @@ app.post('/ads', (request, response) => {
 app.get('/ads', (request, response) => {
   response.header('Access-Control-Allow-Origin', '*')
   AdsService().getAllAds().then(ads => response.json(ads))
-})
-
-app.get('/ads/random', (request, response) => {
-  response.header('Access-Control-Allow-Origin', '*')
-  AdsService().getRandomActiveAd().then(ad => response.json(ad))
 })
 
 app.delete('/ads/:adUid', (request, response) => {
@@ -99,6 +89,11 @@ app.post('/ads/:adUid/disable', (request, response) => {
   AdsService().disableAd(request.params.adUid).then(() => response.send())
 })
 
+app.get('/complaints', (request, response) => {
+  response.header('Access-Control-Allow-Origin', '*')
+  ComplaintService().getComplaintsCountForUsers().then(complaints => response.json(complaints))
+})
+
 app.get('/complaints/:userUid', (request, response) => {
   response.header('Access-Control-Allow-Origin', '*')
   ComplaintService().getComplaintsForUser(request.params.userUid)
@@ -108,6 +103,12 @@ app.get('/complaints/:userUid', (request, response) => {
           response.json({ user: user, complaints: complaints })
         })
     })
+})
+
+app.get('/complaintss/type', (request, response) => {
+  response.header('Access-Control-Allow-Origin', '*')
+  ComplaintService().getComplaintsByType(request.query.startDate, request.query.endDate)
+    .then(complaints => response.json(complaints))
 })
 
 app.post('/users/:userUid/disable', (request, response) => {

--- a/src/index.js
+++ b/src/index.js
@@ -105,16 +105,13 @@ app.get('/complaints/:userUid', (request, response) => {
     })
 })
 
-// TODO: Hay un tema aca que /complaints/type lo interpreta como el get a /complaints/:userUid, asique hay
-// que buscar otra URL
-app.get('/complaintss/type', (request, response) => {
+app.get('/analytics/complaints/type', (request, response) => {
   response.header('Access-Control-Allow-Origin', '*')
   ComplaintService().getComplaintsByType(request.query.startDate, request.query.endDate)
     .then(complaints => response.json(complaints))
 })
 
-// TODO: Idem endpoint anterior
-app.get('/complaintss/disabled', (request, response) => {
+app.get('/analytics/complaints/disabled', (request, response) => {
   response.header('Access-Control-Allow-Origin', '*')
   ComplaintService().getDisabledUsersForType(request.query.type)
     .then(usersWithComplaints => response.json(usersWithComplaints))

--- a/src/services/complaintService.js
+++ b/src/services/complaintService.js
@@ -44,7 +44,7 @@ export default function ComplaintService() {
         .then(complaints => {
           complaints.forEach(complaintsForUser => {
             promisesArrayOfUsers.push(UserService().getUser(complaintsForUser.key).then(user => {
-              return DisableUserService().isUserDisabled(user.Uid).then(isDisabled => {
+              return DisableUserService().isUserBlocked(user.Uid).then(isDisabled => {
                 const counts = calculateCounts(complaintsForUser)
                 const complaint = {
                   total: counts[TOTAL_INDEX],
@@ -134,8 +134,7 @@ export default function ComplaintService() {
         })
       }).then(() => {
         return usersWithComplaintsSet.forEach(user => {
-          // TODO: Warning... there are users that have deleted their account as disabledUsers
-          promisesArray.push(DisableUserService().isUserDisabled(user).then(isDisabled => {
+          promisesArray.push(DisableUserService().isUserBlocked(user).then(isDisabled => {
             if (isDisabled) {
               usersWithComplaintsHash.disabled += 1
             } else {

--- a/src/services/complaintService.js
+++ b/src/services/complaintService.js
@@ -25,11 +25,11 @@ export default function ComplaintService() {
   }
 
   const validTimestamp = (actualTimestamp, startDate, endDate) => {
-    if (startDate) {
+    if (startDate && startDate !== 'undefined') {
       startDate = startDate.concat('-01 00:00:00')
       if (startDate > actualTimestamp) return false
     }
-    if (endDate) {
+    if (endDate && endDate !== 'undefined') {
       endDate = endDate.concat('-31 23:59:59')
       if (actualTimestamp > endDate) return false
     }

--- a/src/services/complaintService.js
+++ b/src/services/complaintService.js
@@ -119,6 +119,33 @@ export default function ComplaintService() {
       })
     },
 
+    getDisabledUsersForType: type => {
+      const complaintsRef = Database('complaints')
+      const usersWithComplaintsArray = []
+      const usersWithComplaintsHash = { disabled: 0, enabled: 0 }
+      const promisesArray = []
+      return complaintsRef.once('value').then(complaints => {
+        return complaints.forEach(user => {
+          return user.forEach(complaint => {
+            if (complaint.val().type === type) {
+              // TODO: Warning... there are users that have deleted their account as disabledUsers
+              promisesArray.push(DisableUserService().isUserDisabled(user.key).then(isDisabled => {
+                if (isDisabled) {
+                  usersWithComplaintsHash.disabled += 1
+                } else {
+                  usersWithComplaintsHash.enabled += 1
+                }
+              }))
+            }
+          })
+        })
+      }).then(() => {
+        return Promise.all(promisesArray).then(() => {
+          return usersWithComplaintsHash
+        })
+      })
+    },
+
     deleteComplaints: userUid => {
       const complaintsRef = Database('complaints')
       return complaintsRef.child(userUid).remove()

--- a/src/services/complaintService.js
+++ b/src/services/complaintService.js
@@ -105,12 +105,13 @@ export default function ComplaintService() {
       return complaintsRef.once('value').then(complaints => {
         return complaints.forEach(userComplaints => {
           return userComplaints.forEach(complaint => {
+            const complaintType = complaint.val().type
             const timestamp = complaint.val().timeStamp
             if (validTimestamp(timestamp, startDate, endDate)) {
-              if (complaintsHash[complaint.val().type]) {
-                complaintsHash[complaint.val().type] += 1
+              if (complaintsHash[complaintType]) {
+                complaintsHash[complaintType] += 1
               } else {
-                complaintsHash[complaint.val().type] = 1
+                complaintsHash[complaintType] = 1
               }
             }
           })
@@ -134,6 +135,7 @@ export default function ComplaintService() {
           })
         })
       }).then(() => {
+        // Get which of those users are disabled
         return Promise.map(usersWithComplaintsSet, user => {
           return DisableUserService().isUserBlocked(user).then(isDisabled => {
             if (isDisabled) {

--- a/src/services/disableUserService.js
+++ b/src/services/disableUserService.js
@@ -3,7 +3,7 @@ import AuthService from './authService'
 import { PushNotificationService } from './pushNotificationService'
 
 export default function DisableUserService() {
-  const isUserDisabled = (userUid, type = undefined) => {
+  const isUserDisabled = (userUid, type) => {
     const ref = Database('disabledUsers')
     return ref.child(userUid).once('value').then(user => {
       return user.exists() && (!type || user.val() === type)

--- a/src/services/disableUserService.js
+++ b/src/services/disableUserService.js
@@ -3,20 +3,20 @@ import AuthService from './authService'
 import { PushNotificationService } from './pushNotificationService'
 
 export default function DisableUserService() {
-  const isUserDisabled = userUid => {
+  const isUserDisabled = (userUid, type = undefined) => {
     const ref = Database('disabledUsers')
     return ref.child(userUid).once('value').then(user => {
-      return user.exists()
+      return user.exists() && (!type || user.val() === type)
     })
   }
 
-  const disableUser = userUid => {
+  const disableUser = (userUid, type) => {
     return Database('users').child(userUid).once('value').then(user => {
       if (!user.exists()) {
         return Promise.reject(new Error('That userUid does not exist'))
       }
       return AuthService().disableUser(userUid).then(() => {
-        return Database('disabledUsers').child(userUid).set(true)
+        return Database('disabledUsers').child(userUid).set(type)
       })
     })
   }
@@ -24,10 +24,16 @@ export default function DisableUserService() {
   return {
     isUserDisabled: isUserDisabled,
 
-    disableUser: disableUser,
+    isUserBlocked: userUid => {
+      return isUserDisabled(userUid, 'blocked')
+    },
+
+    disableDeletedUser: userUid => {
+      return disableUser(userUid, 'deleted')
+    },
 
     blockUser: userUid => {
-      return disableUser(userUid).then(() => {
+      return disableUser(userUid, 'blocked').then(() => {
         return PushNotificationService().sendDisablePush(userUid)
       })
     },

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -278,7 +278,7 @@ export default function UserService() {
       return Administrator().auth().deleteUser(uid)
         .then(() => {
           // Set as disabled user both in Firebase and the app
-          return DisableUserService().disableUser(uid)
+          return DisableUserService().disableDeletedUser(uid)
         })
         .then(() => {
           // Delete unlinks (Although it's not necessary, it's for keeping the DB clean)

--- a/test/factories/complaintsFactory.js
+++ b/test/factories/complaintsFactory.js
@@ -6,6 +6,8 @@ export class Complaint {
         idReporting: 'uid',
         message: 'message',
         state: 'new',
+        type: 'other',
+        timeStamp: '2017-10-30 12:00:00',
         id: Complaint.id
       }
       Complaint.id += 1
@@ -23,6 +25,41 @@ export class Complaint {
 
     denouncerUser(denouncerUserUid) {
       this.complaint.idReporting = denouncerUserUid
+      return this
+    }
+
+    spam() {
+      this.complaint.type = 'spam'
+      return this
+    }
+
+    suspicious() {
+      this.complaint.type = 'suspicious'
+      return this
+    }
+
+    inappropiateMessage() {
+      this.complaint.type = 'inappropiate-message'
+      return this
+    }
+
+    other() {
+      this.complaint.type = 'other'
+      return this
+    }
+
+    fromSeptember() {
+      this.complaint.timeStamp = '2017-09-15 12:00:00'
+      return this
+    }
+
+    fromOctober() {
+      this.complaint.timeStamp = '2017-10-15 12:00:00'
+      return this
+    }
+
+    fromNovember() {
+      this.complaint.timeStamp = '2017-11-15 12:00:00'
       return this
     }
 

--- a/test/services/complaintService.test.js
+++ b/test/services/complaintService.test.js
@@ -430,8 +430,8 @@ describe('complaintService', () => {
     describe('when there are disabledUsers', () => {
       before(() => {
         const disabledUsers = {
-          [maleForFriends.Uid]: true,
-          [femaleForFriends.Uid]: true
+          [maleForFriends.Uid]: 'blocked',
+          [femaleForFriends.Uid]: 'blocked'
         }
         Database('disabledUsers').set(disabledUsers)
       })

--- a/test/services/complaintService.test.js
+++ b/test/services/complaintService.test.js
@@ -254,4 +254,116 @@ describe('complaintService', () => {
       })
     })
   })
+
+  describe('#getComplaintsByType', () => {
+    const maleForFriends = new User().male().likesFriends().get()
+    const femaleForFriends = new User().female().likesFriends().get()
+
+    describe('for different types of complaints', () => {
+      const otherComplaint = new Complaint().other().get()
+      const inappropiateMessageComplaint = new Complaint().inappropiateMessage().get()
+      const suspiciousComplaint = new Complaint().suspicious().get()
+      const spamComplaint = new Complaint().spam().get()
+      const anotherSuspiciousComplaint = new Complaint().suspicious().get()
+      const anotherSpamComplaint = new Complaint().spam().get()
+
+      before(() => {
+        const complaints = {
+          [maleForFriends.Uid]: {
+            [otherComplaint.id]: otherComplaint,
+            [inappropiateMessageComplaint.id]: inappropiateMessageComplaint,
+            [anotherSpamComplaint.id]: anotherSpamComplaint
+          },
+          [femaleForFriends.Uid]: {
+            [suspiciousComplaint.id]: suspiciousComplaint,
+            [spamComplaint.id]: spamComplaint,
+            [anotherSuspiciousComplaint.id]: anotherSuspiciousComplaint
+          }
+        }
+        Database('complaints').set(complaints)
+      })
+
+      it('gets correct amounts of complaints for each type', () => {
+        return ComplaintService().getComplaintsByType(null, null).then(complaints => {
+          expect(complaints['spam']).to.eq(2)
+          expect(complaints['other']).to.eq(1)
+          expect(complaints['suspicious']).to.eq(2)
+          expect(complaints['inappropiate-message']).to.eq(1)
+        })
+      })
+    })
+
+    describe('for different dates', () => {
+      const septemberComplaint = new Complaint().fromSeptember().get()
+      const septemberComplaint2 = new Complaint().fromSeptember().get()
+      const octoberComplaint = new Complaint().fromOctober().get()
+      const novemberComplaint = new Complaint().fromNovember().get()
+      const novemberComplaint2 = new Complaint().fromNovember().get()
+      const novemberComplaint3 = new Complaint().fromNovember().get()
+      const novemberComplaint4 = new Complaint().fromNovember().get()
+
+      before(() => {
+        const complaints = {
+          [maleForFriends.Uid]: {
+            [septemberComplaint.id]: septemberComplaint,
+            [octoberComplaint.id]: octoberComplaint,
+            [novemberComplaint.id]: novemberComplaint
+          },
+          [femaleForFriends.Uid]: {
+            [septemberComplaint2.id]: septemberComplaint2,
+            [novemberComplaint2.id]: novemberComplaint2,
+            [novemberComplaint3.id]: novemberComplaint3,
+            [novemberComplaint4.id]: novemberComplaint4
+          }
+        }
+        Database('complaints').set(complaints)
+      })
+
+      describe('when no specific dates are set', () => {
+        it('returns all complaints', () => {
+          return ComplaintService().getComplaintsByType(undefined, undefined).then(complaints => {
+            expect(complaints['other']).to.eq(7)
+          })
+        })
+      })
+
+      describe('when specifying a startDate', () => {
+        it('returns only complaints with timestamp greater than it', () => {
+          return ComplaintService().getComplaintsByType('2017-10', undefined).then(complaints => {
+            expect(complaints['other']).to.eq(5)
+          })
+        })
+      })
+
+      describe('when specifying an endDate', () => {
+        it('returns only complaints with timestamp lower than it', () => {
+          return ComplaintService().getComplaintsByType(undefined, '2017-10').then(complaints => {
+            expect(complaints['other']).to.eq(3)
+          })
+        })
+      })
+
+      describe('when specifying both startDate and endDate', () => {
+        it('returns only complaints with timestamp between them', () => {
+          return ComplaintService().getComplaintsByType('2017-10', '2017-10').then(complaints => {
+            expect(complaints['other']).to.eq(1)
+          })
+        })
+      })
+
+      describe('when specifying dates that have no complaints', () => {
+        it('returns no complaints', () => {
+          return ComplaintService().getComplaintsByType(undefined, '2017-08').then(complaints => {
+            expect(complaints).to.be.empty
+          })
+        })
+
+        it('returns no complaints', () => {
+          return ComplaintService().getComplaintsByType('2017-12', undefined).then(complaints => {
+            expect(complaints).to.be.empty
+          })
+        })
+      })
+    })
+  })
 })

--- a/test/services/complaintService.test.js
+++ b/test/services/complaintService.test.js
@@ -255,7 +255,7 @@ describe('complaintService', () => {
     })
   })
 
-  describe('#getComplaintsByType', () => {
+  describe('#getComplaintsByType(startDate, endDate)', () => {
     const maleForFriends = new User().male().likesFriends().get()
     const femaleForFriends = new User().female().likesFriends().get()
 
@@ -362,6 +362,98 @@ describe('complaintService', () => {
           return ComplaintService().getComplaintsByType('2017-12', undefined).then(complaints => {
             expect(complaints).to.be.empty
           })
+        })
+      })
+    })
+  })
+
+  describe('#getComplaintsByType(type)', () => {
+    const maleForFriends = new User().male().likesFriends().get()
+    const maleForFriends2 = new User().male().likesFriends().get()
+    const femaleForFriends = new User().female().likesFriends().get()
+    const femaleForFriends2 = new User().female().likesFriends().get()
+
+    const otherComplaint = new Complaint().other().get()
+    const otherComplaint2 = new Complaint().other().get()
+    const suspiciousComplaint = new Complaint().suspicious().get()
+    const suspiciousComplaint2 = new Complaint().suspicious().get()
+    const suspiciousComplaint3 = new Complaint().suspicious().get()
+    const spamComplaint = new Complaint().spam().get()
+    const spamComplaint2 = new Complaint().spam().get()
+    const spamComplaint3 = new Complaint().spam().get()
+
+    before(() => {
+      const complaints = {
+        [maleForFriends.Uid]: {
+          [otherComplaint.id]: otherComplaint,
+          [suspiciousComplaint.id]: suspiciousComplaint
+        },
+        [maleForFriends2.Uid]: {
+          [spamComplaint.id]: spamComplaint,
+          [spamComplaint2.id]: spamComplaint2
+        },
+        [femaleForFriends.Uid]: {
+          [otherComplaint2.id]: otherComplaint2,
+          [suspiciousComplaint2.id]: suspiciousComplaint2,
+          [spamComplaint3.id]: spamComplaint3
+        },
+        [femaleForFriends2.Uid]: {
+          [suspiciousComplaint3.id]: suspiciousComplaint3
+        }
+      }
+      Database('complaints').set(complaints)
+
+      Database('disabledUsers').set({})
+    })
+
+    it('returns the correct amount for other type', () => {
+      return ComplaintService().getDisabledUsersForType('other').then(usersWithComplaints => {
+        expect(usersWithComplaints.enabled).to.eq(2)
+        expect(usersWithComplaints.disabled).to.eq(0)
+      })
+    })
+
+    it('returns the correct amount for spam type', () => {
+      return ComplaintService().getDisabledUsersForType('spam').then(usersWithComplaints => {
+        expect(usersWithComplaints.enabled).to.eq(2)
+        expect(usersWithComplaints.disabled).to.eq(0)
+      })
+    })
+
+    it('returns the correct amount for suspicious type', () => {
+      return ComplaintService().getDisabledUsersForType('suspicious').then(usersWithComplaints => {
+        expect(usersWithComplaints.enabled).to.eq(3)
+        expect(usersWithComplaints.disabled).to.eq(0)
+      })
+    })
+
+    describe('when there are disabledUsers', () => {
+      before(() => {
+        const disabledUsers = {
+          [maleForFriends.Uid]: true,
+          [femaleForFriends.Uid]: true
+        }
+        Database('disabledUsers').set(disabledUsers)
+      })
+
+      it('returns the correct amount for other type', () => {
+        return ComplaintService().getDisabledUsersForType('other').then(usersWithComplaints => {
+          expect(usersWithComplaints.enabled).to.eq(0)
+          expect(usersWithComplaints.disabled).to.eq(2)
+        })
+      })
+
+      it('returns the correct amount for spam type', () => {
+        return ComplaintService().getDisabledUsersForType('spam').then(usersWithComplaints => {
+          expect(usersWithComplaints.enabled).to.eq(1)
+          expect(usersWithComplaints.disabled).to.eq(1)
+        })
+      })
+
+      it('returns the correct amount for suspicious type', () => {
+        return ComplaintService().getDisabledUsersForType('suspicious').then(usersWithComplaints => {
+          expect(usersWithComplaints.enabled).to.eq(1)
+          expect(usersWithComplaints.disabled).to.eq(2)
         })
       })
     })

--- a/test/services/complaintService.test.js
+++ b/test/services/complaintService.test.js
@@ -367,7 +367,7 @@ describe('complaintService', () => {
     })
   })
 
-  describe('#getComplaintsByType(type)', () => {
+  describe('#getDisabledUsersForType(type)', () => {
     const maleForFriends = new User().male().likesFriends().get()
     const maleForFriends2 = new User().male().likesFriends().get()
     const femaleForFriends = new User().female().likesFriends().get()

--- a/test/services/disableUserService.test.js
+++ b/test/services/disableUserService.test.js
@@ -30,6 +30,7 @@ describe('disableUserService', () => {
         return DisableUserService().blockUser(maleForFriends.Uid).then(() => {
           return Database('disabledUsers').child(maleForFriends.Uid.toString()).once('value').then(result => {
             expect(result.exists()).to.be.true
+            expect(result.val()).to.equal('blocked')
           })
         })
       })
@@ -44,7 +45,7 @@ describe('disableUserService', () => {
     describe('There is a user disabled', () => {
       before(() => {
         const disabledUsers = {
-          [femaleForFriends.Uid]: true
+          [femaleForFriends.Uid]: 'blocked'
         }
         Database('disabledUsers').set(disabledUsers)
         DisableUserService().blockUser(maleForFriends.Uid)
@@ -87,7 +88,7 @@ describe('disableUserService', () => {
     describe('There is a user disabled', () => {
       before(() => {
         const disabledUsers = {
-          [femaleForFriends.Uid]: true
+          [femaleForFriends.Uid]: 'blocked'
         }
         Database('disabledUsers').set(disabledUsers)
       })
@@ -104,8 +105,8 @@ describe('disableUserService', () => {
     describe('Both users are disabled', () => {
       before(() => {
         const disabledUsers = {
-          [femaleForFriends.Uid]: true,
-          [maleForFriends.Uid]: true
+          [femaleForFriends.Uid]: 'blocked',
+          [maleForFriends.Uid]: 'blocked'
         }
         Database('disabledUsers').set(disabledUsers)
         DisableUserService().unblockUser(maleForFriends.Uid)
@@ -144,7 +145,7 @@ describe('disableUserService', () => {
     describe('One disabled user', () => {
       before(() => {
         const disabledUsers = {
-          [femaleForFriends.Uid]: true
+          [femaleForFriends.Uid]: 'blocked'
         }
         Database('disabledUsers').set(disabledUsers)
       })
@@ -165,13 +166,13 @@ describe('disableUserService', () => {
     describe('Both users are disabled', () => {
       before(() => {
         const disabledUsers = {
-          [femaleForFriends.Uid]: true,
-          [maleForFriends.Uid]: true
+          [femaleForFriends.Uid]: 'blocked',
+          [maleForFriends.Uid]: 'blocked'
         }
         Database('disabledUsers').set(disabledUsers)
       })
 
-      it('should return false', () => {
+      it('should return true', () => {
         return DisableUserService().isUserDisabled(maleForFriends.Uid).then(result => {
           expect(result).to.be.true
         })
@@ -181,6 +182,53 @@ describe('disableUserService', () => {
         return DisableUserService().isUserDisabled(femaleForFriends.Uid).then(result => {
           expect(result).to.be.true
         })
+      })
+    })
+
+    describe('when there are blocked and deleted users', () => {
+      before(() => {
+        const disabledUsers = {
+          [femaleForFriends.Uid]: 'blocked',
+          [maleForFriends.Uid]: 'deleted'
+        }
+        Database('disabledUsers').set(disabledUsers)
+      })
+
+      it('returns true for the blocked user', () => {
+        return DisableUserService().isUserDisabled(femaleForFriends.Uid).then(result => {
+          expect(result).to.be.true
+        })
+      })
+
+      it('returns true for the deleted user', () => {
+        return DisableUserService().isUserDisabled(maleForFriends.Uid).then(result => {
+          expect(result).to.be.true
+        })
+      })
+    })
+  })
+
+  describe('isUserBlocked', () => {
+    const maleForFriends = new User().male().likesFriends().get()
+    const femaleForFriends = new User().female().likesFriends().get()
+
+    before(() => {
+      const disabledUsers = {
+        [femaleForFriends.Uid]: 'blocked',
+        [maleForFriends.Uid]: 'deleted'
+      }
+      Database('disabledUsers').set(disabledUsers)
+    })
+
+    it('returns true for the blocked user', () => {
+      return DisableUserService().isUserBlocked(femaleForFriends.Uid).then(result => {
+        expect(result).to.be.true
+      })
+    })
+
+    it('returns false for the deleted user', () => {
+      return DisableUserService().isUserBlocked(maleForFriends.Uid).then(result => {
+        expect(result).to.be.false
       })
     })
   })

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -591,7 +591,7 @@ describe('UserService', () => {
             [femaleForMaleWithOneInterest.Uid]: femaleForMaleWithOneInterest
           }
           const disabledUsers = {
-            [maleForFemaleWithManyInterests.Uid]: true
+            [maleForFemaleWithManyInterests.Uid]: 'blocked'
           }
           const ref = Database('users')
           ref.set(users)
@@ -615,7 +615,7 @@ describe('UserService', () => {
             [femaleForMaleWithOneInterest.Uid]: femaleForMaleWithOneInterest
           }
           const disabledUsers = {
-            [maleForFemaleWithManyInterests.Uid]: true
+            [maleForFemaleWithManyInterests.Uid]: 'blocked'
           }
           const ref = Database('users')
           ref.set(users)
@@ -640,8 +640,8 @@ describe('UserService', () => {
             [femaleForMaleWithOneInterest.Uid]: femaleForMaleWithOneInterest
           }
           const disabledUsers = {
-            [maleForFemaleWithManyInterests.Uid]: true,
-            [maleForMaleAndFemale.Uid]: true
+            [maleForFemaleWithManyInterests.Uid]: 'blocked',
+            [maleForMaleAndFemale.Uid]: 'blocked'
           }
           const ref = Database('users')
           ref.set(users)


### PR DESCRIPTION
Genero los endpoints para que el administrador pueda consultar:
- Cantidad de denuncias recibidas en un período de tiempo, según el tipo.
- Cantidad de usuarios que recibieron un tipo de denuncia, diferenciándolos por si fueron deshabilitados o no.

### TODO
- [x] Arreglar unas cosas de los endpoints, ya que se pisan con otros nombres.
- [x] Arreglar lo del `disabledUsers` -> Ahora me estoy fijando en esa tabla si fue deshabilitado o no, pero también estamos guardando usuarios que eliminaron sus cuentas ahí. Tal vez habría que modificar la estructura de la tabla para que sea algo del tipo:
```json
disabledUsers: {
  "unId": "deleted",
  "otroId": "disabled"
}
```
Y fijarse así que hayan sido sólo los `disabled`