### PR TITLE
Create ad with filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.1.3"
+  - "8.9.0"
 
 cache:
   directories:

--- a/src/services/adsService.js
+++ b/src/services/adsService.js
@@ -77,11 +77,7 @@ export default function AdsService() {
       if (!correctness.result) {
         return Promise.reject(correctness.message)
       }
-      return adsRef.push({
-        title: ad.title,
-        image: ad.image,
-        state: ad.state
-      })
+      return adsRef.push(ad)
     }
   }
 }

--- a/src/services/schemas/adSchema.js
+++ b/src/services/schemas/adSchema.js
@@ -4,9 +4,11 @@ const adSchema = {
   'properties': {
     'title': { 'type': 'string' },
     'image': { 'type': 'string' },
-    'state': { 'type': 'string' }
+    'state': { 'type': 'string' },
+    'target': { 'type': 'string' },
+    'ageRange': { 'type': 'object' }
   },
-  'required': ['title', 'image', 'state']
+  'required': ['title', 'image', 'state', 'target', 'ageRange']
 }
 
 export default adSchema

--- a/test/factories/adsFactory.js
+++ b/test/factories/adsFactory.js
@@ -5,9 +5,16 @@ export class Ad {
     this.ad = {
       id: Ad.id.toString(),
       title: title,
-      image: image
+      image: image,
+      ageRange: { min: 18, max: 100 },
+      target: 'All'
     }
     Ad.id += 1
+  }
+
+  setAgeRange(ageRange) {
+    this.ad.ageRange = ageRange
+    return this
   }
 
   active() {
@@ -17,6 +24,21 @@ export class Ad {
 
   disabled() {
     this.ad.state = 'Disabled'
+    return this
+  }
+
+  forAll() {
+    this.ad.target = 'All'
+    return this
+  }
+
+  forMale() {
+    this.ad.target = 'Male'
+    return this
+  }
+
+  forFemale() {
+    this.ad.target = 'Female'
     return this
   }
 

--- a/test/services/adsService.test.js
+++ b/test/services/adsService.test.js
@@ -132,7 +132,7 @@ describe('adsService', () => {
           })
       })
 
-      it('should responde with error if title is undefined', () => {
+      it('should respond with error if title is undefined', () => {
         return AdsService().createAd({
           image: facebookAd.image,
           state: facebookAd.state
@@ -145,7 +145,7 @@ describe('adsService', () => {
           })
       })
 
-      it('should responde with error if image undefined', () => {
+      it('should respond with error if image undefined', () => {
         return AdsService().createAd({
           title: facebookAd.title,
           state: facebookAd.state
@@ -158,7 +158,7 @@ describe('adsService', () => {
           })
       })
 
-      it('should responde with error if state is undefined', () => {
+      it('should respond with error if state is undefined', () => {
         return AdsService().createAd({
           title: facebookAd.title,
           image: facebookAd.image
@@ -177,13 +177,18 @@ describe('adsService', () => {
         return AdsService().createAd({
           title: facebookAd.title,
           image: facebookAd.image,
-          state: facebookAd.state
+          state: facebookAd.state,
+          ageRange: facebookAd.ageRange,
+          target: facebookAd.target
         }).then(() => {
           return AdsService().getAllAds().then(ads => {
             expect(ads.length).to.equal(1)
             expect(ads[0].title).to.equal(facebookAd.title)
             expect(ads[0].image).to.equal(facebookAd.image)
             expect(ads[0].state).to.equal(facebookAd.state)
+            expect(ads[0].ageRange.max).to.equal(facebookAd.ageRange.max)
+            expect(ads[0].ageRange.min).to.equal(facebookAd.ageRange.min)
+            expect(ads[0].target).to.equal(facebookAd.target)
           })
         })
       })
@@ -201,13 +206,18 @@ describe('adsService', () => {
         return AdsService().createAd({
           title: facebookAd.title,
           image: facebookAd.image,
-          state: facebookAd.state
+          state: facebookAd.state,
+          ageRange: facebookAd.ageRange,
+          target: facebookAd.target
         }).then(() => {
           return AdsService().getAllAds().then(ads => {
             expect(ads.length).to.equal(2)
             expect(ads[1].title).to.equal(facebookAd.title)
             expect(ads[1].image).to.equal(facebookAd.image)
             expect(ads[1].state).to.equal(facebookAd.state)
+            expect(ads[1].ageRange.max).to.equal(facebookAd.ageRange.max)
+            expect(ads[1].ageRange.min).to.equal(facebookAd.ageRange.min)
+            expect(ads[1].target).to.equal(facebookAd.target)
           })
         })
       })


### PR DESCRIPTION
Permite crear publicidades con `target` y `ageRange`

Bonus: Subo la version de node a 8.9 (desde hoy `LTS`)