### PR TITLE
Active users data

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.2",
     "cors": "^2.8.4",
+    "dateformat": "^3.0.2",
     "express": "4.15.2",
     "firebase": "^4.3.1",
     "firebase-admin": "^5.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,12 @@ app.post('/users/:userUid/enable', (request, response) => {
     })
 })
 
+app.get('/analytics/users', (request, response) => {
+  response.header('Access-Control-Allow-Origin', '*')
+  UserService().getActiveUsers(request.query.startDate, request.query.endDate)
+    .then(users => response.json(users))
+})
+
 // For the app
 app.get('/users', (request, response) => {
   if (!request.get('token')) {

--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,7 @@ app.get('/users', (request, response) => {
     .then(decodedToken => {
       const uid = decodedToken.uid
       UserController().getUsersForUser(uid).then(usersWithAd => response.json(usersWithAd))
+      UserService().updateUserActivity(uid)
     })
     .catch(error => {
       response.status(403)

--- a/src/services/complaintService.js
+++ b/src/services/complaintService.js
@@ -2,6 +2,7 @@ import Database from './gateway/database'
 import UserService from './userService'
 import DisableUserService from './disableUserService'
 import Promise from 'bluebird'
+import { validTimestamp } from './dateService'
 
 export default function ComplaintService() {
   const TOTAL_INDEX = 0
@@ -22,18 +23,6 @@ export default function ComplaintService() {
 
   const translateCondition = isDisabled => {
     return isDisabled ? 'Disabled' : 'Active'
-  }
-
-  const validTimestamp = (actualTimestamp, startDate, endDate) => {
-    if (startDate && startDate !== 'undefined') {
-      startDate = startDate.concat('-01 00:00:00')
-      if (startDate > actualTimestamp) return false
-    }
-    if (endDate && endDate !== 'undefined') {
-      endDate = endDate.concat('-31 23:59:59')
-      if (actualTimestamp > endDate) return false
-    }
-    return true
   }
 
   return {

--- a/src/services/dateService.js
+++ b/src/services/dateService.js
@@ -42,23 +42,6 @@ export const getDatesBetween = (startDate, endDate) => {
   return dates
 }
 
-export const getDatesBetween2 = (startDate, endDate) => {
-  const day = 1000 * 60 * 60 * 24
-  const date1 = new Date(`${startDate}-02`)
-  const date2 = new Date(`${endDate}-28`)
-
-  const dates = new Set()
-  const diff = (date2.getTime() - date1.getTime()) / day
-  for (let i = 0; i <= diff; i++) {
-    const xx = date1.getTime() + day * i
-    const yy = new Date(xx)
-    const date = dateFormat(yy, 'yyyy-mm')
-
-    dates.add(date)
-  }
-  return dates
-}
-
 export const getActualDate = () => {
   const now = new Date()
   return dateFormat(now, 'yyyy-mm')

--- a/src/services/dateService.js
+++ b/src/services/dateService.js
@@ -1,3 +1,5 @@
+import dateFormat from 'dateformat'
+
 export const validTimestamp = (actualTimestamp, startDate, endDate) => {
   if (startDate && startDate !== 'undefined') {
     startDate = startDate.concat('-01 00:00:00')
@@ -18,4 +20,9 @@ export const validDate = (actualDate, startDate, endDate) => {
     if (actualDate > endDate) return false
   }
   return true
+}
+
+export const getActualDate = () => {
+  const now = new Date()
+  return dateFormat(now, 'yyyy-mm')
 }

--- a/src/services/dateService.js
+++ b/src/services/dateService.js
@@ -22,6 +22,43 @@ export const validDate = (actualDate, startDate, endDate) => {
   return true
 }
 
+const addMonth = currentDate => {
+  const date = new Date(currentDate.valueOf())
+  date.setMonth(date.getMonth() + 1)
+  return date
+}
+
+export const getDatesBetween = (startDate, endDate) => {
+  const dates = []
+  const date1 = new Date(`${startDate}-02`)
+  const date2 = new Date(`${endDate}-28`)
+  let currentDate = date1
+
+  while (currentDate <= date2) {
+    const date = dateFormat(currentDate, 'yyyy-mm')
+    dates.push(date)
+    currentDate = addMonth(currentDate)
+  }
+  return dates
+}
+
+export const getDatesBetween2 = (startDate, endDate) => {
+  const day = 1000 * 60 * 60 * 24
+  const date1 = new Date(`${startDate}-02`)
+  const date2 = new Date(`${endDate}-28`)
+
+  const dates = new Set()
+  const diff = (date2.getTime() - date1.getTime()) / day
+  for (let i = 0; i <= diff; i++) {
+    const xx = date1.getTime() + day * i
+    const yy = new Date(xx)
+    const date = dateFormat(yy, 'yyyy-mm')
+
+    dates.add(date)
+  }
+  return dates
+}
+
 export const getActualDate = () => {
   const now = new Date()
   return dateFormat(now, 'yyyy-mm')

--- a/src/services/dateService.js
+++ b/src/services/dateService.js
@@ -1,0 +1,21 @@
+export const validTimestamp = (actualTimestamp, startDate, endDate) => {
+  if (startDate && startDate !== 'undefined') {
+    startDate = startDate.concat('-01 00:00:00')
+    if (startDate > actualTimestamp) return false
+  }
+  if (endDate && endDate !== 'undefined') {
+    endDate = endDate.concat('-31 23:59:59')
+    if (actualTimestamp > endDate) return false
+  }
+  return true
+}
+
+export const validDate = (actualDate, startDate, endDate) => {
+  if (startDate && startDate !== 'undefined') {
+    if (startDate > actualDate) return false
+  }
+  if (endDate && endDate !== 'undefined') {
+    if (actualDate > endDate) return false
+  }
+  return true
+}

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -10,8 +10,7 @@ import Administrator from './gateway/administrator'
 import { MatchService } from './matchService'
 import { ChatService } from './chatService'
 import ComplaintService from './complaintService'
-import dateFormat from 'dateformat'
-import { validDate } from './dateService'
+import { validDate, getActualDate } from './dateService'
 
 // Available superlinks
 export const PREMIUM_SUPERLINKS = 10
@@ -306,8 +305,7 @@ export default function UserService() {
     updateUserActivity: uid => {
       return UserService().hasLinkUpPlus(uid).then(hasLinkUpPlus => {
         const premium = hasLinkUpPlus || null // null deletes if exists
-        const now = new Date()
-        const currentDate = dateFormat(now, 'yyyy-mm')
+        const currentDate = getActualDate()
         const updates = {}
         updates[`${currentDate}/users/${uid}`] = true
         updates[`${currentDate}/premiumUsers/${uid}`] = premium

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -300,6 +300,15 @@ export default function UserService() {
           // Delete matches and add 'block' for the other user
           return MatchService().deleteMatches(uid)
         })
+    },
+    updateUserActivity: uid => {
+      return UserService().hasLinkUpPlus(uid).then(hasLinkUpPlus => {
+        const premium = hasLinkUpPlus || null // null deletes if exists
+        const updates = {}
+        updates[`users/${uid}`] = true
+        updates[`premiumUsers/${uid}`] = premium
+        return Database('activeUsers').update(updates)
+      })
     }
   }
 }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -11,6 +11,7 @@ import { MatchService } from './matchService'
 import { ChatService } from './chatService'
 import ComplaintService from './complaintService'
 import dateFormat from 'dateformat'
+import { validDate } from './dateService'
 
 // Available superlinks
 export const PREMIUM_SUPERLINKS = 10
@@ -311,6 +312,24 @@ export default function UserService() {
         updates[`${currentDate}/users/${uid}`] = true
         updates[`${currentDate}/premiumUsers/${uid}`] = premium
         return Database('activeUsers').update(updates)
+      })
+    },
+    // This returns only the dates where there is data, it does not fill with 0 between the dates requested
+    getActiveUsers: (startDate, endDate) => {
+      const activeUsersRef = Database('activeUsers')
+      const activeUsersHash = {}
+      return activeUsersRef.once('value').then(activeUsersPerMonth => {
+        return activeUsersPerMonth.forEach(activeUsersInMonth => {
+          const timestamp = activeUsersInMonth.key
+          if (validDate(timestamp, startDate, endDate)) {
+            activeUsersHash[timestamp] = {
+              users: activeUsersInMonth.child('users').numChildren(),
+              premiumUsers: activeUsersInMonth.child('premiumUsers').numChildren()
+            }
+          }
+        })
+      }).then(() => {
+        return activeUsersHash
       })
     }
   }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -10,6 +10,7 @@ import Administrator from './gateway/administrator'
 import { MatchService } from './matchService'
 import { ChatService } from './chatService'
 import ComplaintService from './complaintService'
+import dateFormat from 'dateformat'
 
 // Available superlinks
 export const PREMIUM_SUPERLINKS = 10
@@ -304,9 +305,11 @@ export default function UserService() {
     updateUserActivity: uid => {
       return UserService().hasLinkUpPlus(uid).then(hasLinkUpPlus => {
         const premium = hasLinkUpPlus || null // null deletes if exists
+        const now = new Date()
+        const currentDate = dateFormat(now, 'yyyy-mm')
         const updates = {}
-        updates[`users/${uid}`] = true
-        updates[`premiumUsers/${uid}`] = premium
+        updates[`${currentDate}/users/${uid}`] = true
+        updates[`${currentDate}/premiumUsers/${uid}`] = premium
         return Database('activeUsers').update(updates)
       })
     }

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -943,7 +943,6 @@ describe('UserService', () => {
     const currentDate = dateFormat(now, 'yyyy-mm')
 
     before(() => {
-      console.log(currentDate)
       usersRef.set(users)
     })
 

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -13,6 +13,7 @@ import UserService, {
 import Database from '../../src/services/gateway/database'
 import { User, Interests } from '../factories/usersFactory'
 import { SUPERLINK, LINK, UNLINK, NO_LINK } from '../../src/services/linkService'
+import dateFormat from 'dateformat'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -929,7 +930,7 @@ describe('UserService', () => {
     })
   })
 
-  describe('#updateUserActivity(uid)', () => {
+  describe.only('#updateUserActivity(uid)', () => {
     const activeUsersRef = Database('activeUsers')
     const usersRef = Database('users')
     const freeUser = new User().male().get()
@@ -938,8 +939,11 @@ describe('UserService', () => {
       [freeUser.Uid]: freeUser,
       [premiumUser.Uid]: premiumUser
     }
+    const now = new Date()
+    const currentDate = dateFormat(now, 'yyyy-mm')
 
     before(() => {
+      console.log(currentDate)
       usersRef.set(users)
     })
 
@@ -950,7 +954,7 @@ describe('UserService', () => {
 
       it('updates the activeUsers for the freeUser', () => {
         return UserService().updateUserActivity(freeUser.Uid).then(() => {
-          return activeUsersRef.child(`users/${freeUser.Uid}`).once('value').then(snapshot => {
+          return activeUsersRef.child(`${currentDate}/users/${freeUser.Uid}`).once('value').then(snapshot => {
             expect(snapshot.exists()).to.be.true
           })
         })
@@ -958,25 +962,28 @@ describe('UserService', () => {
 
       it('updates the activeUsers for the premiumUser', () => {
         return UserService().updateUserActivity(premiumUser.Uid).then(() => {
-          return activeUsersRef.child(`users/${premiumUser.Uid}`).once('value').then(snapshot => {
-            expect(snapshot.exists()).to.be.true
-          })
+          return activeUsersRef.child(`${currentDate}/users/${premiumUser.Uid}`).once('value')
+            .then(snapshot => {
+              expect(snapshot.exists()).to.be.true
+            })
         })
       })
 
       it('does not update the activeUsers in premiumUsers for the freeUser', () => {
         return UserService().updateUserActivity(freeUser.Uid).then(() => {
-          return activeUsersRef.child(`premiumUsers/${freeUser.Uid}`).once('value').then(snapshot => {
-            expect(snapshot.exists()).to.be.false
-          })
+          return activeUsersRef.child(`${currentDate}/premiumUsers/${freeUser.Uid}`).once('value')
+            .then(snapshot => {
+              expect(snapshot.exists()).to.be.false
+            })
         })
       })
 
       it('updates the activeUsers in premiumUsers for the premiumUser', () => {
         return UserService().updateUserActivity(premiumUser.Uid).then(() => {
-          return activeUsersRef.child(`premiumUsers/${premiumUser.Uid}`).once('value').then(snapshot => {
-            expect(snapshot.exists()).to.be.true
-          })
+          return activeUsersRef.child(`${currentDate}/premiumUsers/${premiumUser.Uid}`).once('value')
+            .then(snapshot => {
+              expect(snapshot.exists()).to.be.true
+            })
         })
       })
     })
@@ -999,33 +1006,37 @@ describe('UserService', () => {
 
         it('updates the activeUsers for the freeUser', () => {
           return UserService().updateUserActivity(freeUser.Uid).then(() => {
-            return activeUsersRef.child(`users/${freeUser.Uid}`).once('value').then(snapshot => {
-              expect(snapshot.exists()).to.be.true
-            })
+            return activeUsersRef.child(`${currentDate}/users/${freeUser.Uid}`).once('value')
+              .then(snapshot => {
+                expect(snapshot.exists()).to.be.true
+              })
           })
         })
 
         it('updates the activeUsers for the premiumUser', () => {
           return UserService().updateUserActivity(premiumUser.Uid).then(() => {
-            return activeUsersRef.child(`users/${premiumUser.Uid}`).once('value').then(snapshot => {
-              expect(snapshot.exists()).to.be.true
-            })
+            return activeUsersRef.child(`${currentDate}/users/${premiumUser.Uid}`).once('value')
+              .then(snapshot => {
+                expect(snapshot.exists()).to.be.true
+              })
           })
         })
 
         it('does not update the activeUsers in premiumUsers for the freeUser', () => {
           return UserService().updateUserActivity(freeUser.Uid).then(() => {
-            return activeUsersRef.child(`premiumUsers/${freeUser.Uid}`).once('value').then(snapshot => {
-              expect(snapshot.exists()).to.be.false
-            })
+            return activeUsersRef.child(`${currentDate}/premiumUsers/${freeUser.Uid}`).once('value')
+              .then(snapshot => {
+                expect(snapshot.exists()).to.be.false
+              })
           })
         })
 
         it('updates the activeUsers in premiumUsers for the premiumUser', () => {
           return UserService().updateUserActivity(premiumUser.Uid).then(() => {
-            return activeUsersRef.child(`premiumUsers/${premiumUser.Uid}`).once('value').then(snapshot => {
-              expect(snapshot.exists()).to.be.true
-            })
+            return activeUsersRef.child(`${currentDate}/premiumUsers/${premiumUser.Uid}`).once('value')
+              .then(snapshot => {
+                expect(snapshot.exists()).to.be.true
+              })
           })
         })
       })
@@ -1053,33 +1064,37 @@ describe('UserService', () => {
 
         it('updates the activeUsers for the freeUser', () => {
           return UserService().updateUserActivity(freeUser.Uid).then(() => {
-            return activeUsersRef.child(`users/${freeUser.Uid}`).once('value').then(snapshot => {
-              expect(snapshot.exists()).to.be.true
-            })
+            return activeUsersRef.child(`${currentDate}/users/${freeUser.Uid}`).once('value')
+              .then(snapshot => {
+                expect(snapshot.exists()).to.be.true
+              })
           })
         })
 
         it('updates the activeUsers for the premiumUser', () => {
           return UserService().updateUserActivity(premiumUser.Uid).then(() => {
-            return activeUsersRef.child(`users/${premiumUser.Uid}`).once('value').then(snapshot => {
-              expect(snapshot.exists()).to.be.true
-            })
+            return activeUsersRef.child(`${currentDate}/users/${premiumUser.Uid}`).once('value')
+              .then(snapshot => {
+                expect(snapshot.exists()).to.be.true
+              })
           })
         })
 
         it('updates the activeUsers in premiumUsers for the freeUser (now premium)', () => {
           return UserService().updateUserActivity(freeUser.Uid).then(() => {
-            return activeUsersRef.child(`premiumUsers/${freeUser.Uid}`).once('value').then(snapshot => {
-              expect(snapshot.exists()).to.be.true
-            })
+            return activeUsersRef.child(`${currentDate}/premiumUsers/${freeUser.Uid}`).once('value')
+              .then(snapshot => {
+                expect(snapshot.exists()).to.be.true
+              })
           })
         })
 
         it('updates the activeUsers in premiumUsers for the premiumUser (now free)', () => {
           return UserService().updateUserActivity(premiumUser.Uid).then(() => {
-            return activeUsersRef.child(`premiumUsers/${premiumUser.Uid}`).once('value').then(snapshot => {
-              expect(snapshot.exists()).to.be.false
-            })
+            return activeUsersRef.child(`${currentDate}/premiumUsers/${premiumUser.Uid}`).once('value')
+              .then(snapshot => {
+                expect(snapshot.exists()).to.be.false
+              })
           })
         })
       })

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -930,7 +930,7 @@ describe('UserService', () => {
     })
   })
 
-  describe.only('#updateUserActivity(uid)', () => {
+  describe('#updateUserActivity(uid)', () => {
     const activeUsersRef = Database('activeUsers')
     const usersRef = Database('users')
     const freeUser = new User().male().get()
@@ -1094,6 +1094,129 @@ describe('UserService', () => {
               .then(snapshot => {
                 expect(snapshot.exists()).to.be.false
               })
+          })
+        })
+      })
+    })
+  })
+
+  describe('#getActiveUsers(startDate, endDate)', () => {
+    const activeUsersRef = Database('activeUsers')
+    const allActiveUsers = {
+      '2017-09': {
+        'users': 2,
+        'premiumUsers': 1
+      },
+      '2017-10': {
+        'users': 4,
+        'premiumUsers': 2
+      },
+      '2017-11': {
+        'users': 1,
+        'premiumUsers': 0
+      }
+    }
+
+    describe('when there are no activeUsers', () => {
+      before(() => {
+        activeUsersRef.set({})
+      })
+
+      describe('when calling without dates', () => {
+        it('returns an empty hash', () => {
+          return UserService().getActiveUsers().then(users => {
+            expect(users).to.be.empty
+          })
+        })
+      })
+    })
+
+    describe('when there are activeUsers', () => {
+      before(() => {
+        const activeUsers = {
+          '2017-09': {
+            'users': {
+              'user1': true,
+              'user2': true
+            },
+            'premiumUsers': {
+              'user2': true
+            }
+          },
+          '2017-10': {
+            'users': {
+              'user1': true,
+              'user2': true,
+              'user3': true,
+              'user4': true
+            },
+            'premiumUsers': {
+              'user1': true,
+              'user3': true
+            }
+          },
+          '2017-11': {
+            'users': {
+              'user1': true
+            }
+          }
+        }
+        activeUsersRef.set(activeUsers)
+      })
+
+      describe('when calling without dates', () => {
+        it('returns all active users', () => {
+          return UserService().getActiveUsers().then(users => {
+            expect(users).to.deep.equal(allActiveUsers)
+          })
+        })
+
+        it('returns all active users', () => {
+          return UserService().getActiveUsers('undefined', 'undefined').then(users => {
+            expect(users).to.deep.equal(allActiveUsers)
+          })
+        })
+      })
+
+      describe('when calling with dates', () => {
+        describe('when calling with all available dates', () => {
+          it('returns data between those dates', () => {
+            return UserService().getActiveUsers('2017-09', '2017-11').then(users => {
+              expect(users).to.deep.equal(allActiveUsers)
+            })
+          })
+        })
+
+        describe('when calling with more dates than available', () => {
+          it('returns data between those dates', () => {
+            return UserService().getActiveUsers('2017-08', '2017-12').then(users => {
+              expect(users).to.deep.equal(allActiveUsers)
+            })
+          })
+        })
+
+        describe('when calling with a subset of the available dates', () => {
+          it('returns data between those dates', () => {
+            return UserService().getActiveUsers('2017-10', '2017-11').then(users => {
+              expect(users).to.deep.equal({
+                '2017-10': {
+                  'users': 4,
+                  'premiumUsers': 2
+                },
+                '2017-11': {
+                  'users': 1,
+                  'premiumUsers': 0
+                }
+              })
+            })
+          })
+        })
+
+        describe('when calling with dates without data', () => {
+          it('returns an empty hash', () => {
+            return UserService().getActiveUsers('2017-12', '2018-02').then(users => {
+              expect(users).to.be.empty
+            })
           })
         })
       })

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -13,7 +13,7 @@ import UserService, {
 import Database from '../../src/services/gateway/database'
 import { User, Interests } from '../factories/usersFactory'
 import { SUPERLINK, LINK, UNLINK, NO_LINK } from '../../src/services/linkService'
-import dateFormat from 'dateformat'
+import { getActualDate } from '../../src/services/dateService'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -939,8 +939,7 @@ describe('UserService', () => {
       [freeUser.Uid]: freeUser,
       [premiumUser.Uid]: premiumUser
     }
-    const now = new Date()
-    const currentDate = dateFormat(now, 'yyyy-mm')
+    const currentDate = getActualDate()
 
     before(() => {
       usersRef.set(users)

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -1128,6 +1128,14 @@ describe('UserService', () => {
           })
         })
       })
+
+      describe('when calling with dates', () => {
+        it('returns an empty hash', () => {
+          return UserService().getActiveUsers('2017-09', '2017-11').then(users => {
+            expect(users).to.be.empty
+          })
+        })
+      })
     })
 
     describe('when there are activeUsers', () => {
@@ -1177,6 +1185,49 @@ describe('UserService', () => {
         })
       })
 
+      describe('when calling only with startDate', () => {
+        it('returns data since then until today', () => {
+          return UserService().getActiveUsers('2017-08').then(users => {
+            expect(users).to.deep.equal({
+              ...allActiveUsers,
+              '2017-08': {
+                'users': 0,
+                'premiumUsers': 0
+              }
+            })
+          })
+        })
+      })
+
+      describe('when calling only with endDate', () => {
+        it('returns data since the first day of data until endDate', () => {
+          return UserService().getActiveUsers(undefined, '2017-10').then(users => {
+            expect(users).to.deep.equal({
+              '2017-09': {
+                'users': 2,
+                'premiumUsers': 1
+              },
+              '2017-10': {
+                'users': 4,
+                'premiumUsers': 2
+              }
+            })
+          })
+        })
+
+        it('returns data since the first day of data until endDate', () => {
+          return UserService().getActiveUsers(undefined, '2017-12').then(users => {
+            expect(users).to.deep.equal({
+              ...allActiveUsers,
+              '2017-12': {
+                'users': 0,
+                'premiumUsers': 0
+              }
+            })
+          })
+        })
+      })
+
       describe('when calling with dates', () => {
         describe('when calling with all available dates', () => {
           it('returns data between those dates', () => {
@@ -1189,7 +1240,17 @@ describe('UserService', () => {
         describe('when calling with more dates than available', () => {
           it('returns data between those dates', () => {
             return UserService().getActiveUsers('2017-08', '2017-12').then(users => {
-              expect(users).to.deep.equal(allActiveUsers)
+              expect(users).to.deep.equal({
+                ...allActiveUsers,
+                '2017-08': {
+                  'users': 0,
+                  'premiumUsers': 0
+                },
+                '2017-12': {
+                  'users': 0,
+                  'premiumUsers': 0
+                }
+              })
             })
           })
         })
@@ -1214,7 +1275,20 @@ describe('UserService', () => {
         describe('when calling with dates without data', () => {
           it('returns an empty hash', () => {
             return UserService().getActiveUsers('2017-12', '2018-02').then(users => {
-              expect(users).to.be.empty
+              expect(users).to.deep.equal({
+                '2017-12': {
+                  'users': 0,
+                  'premiumUsers': 0
+                },
+                '2018-01': {
+                  'users': 0,
+                  'premiumUsers': 0
+                },
+                '2018-02': {
+                  'users': 0,
+                  'premiumUsers': 0
+                }
+              })
             })
           })
         })


### PR DESCRIPTION
Creo la tabla `activeUsers` con el siguiente formato, para que pueda ser consumida para el reporte de usuarios activos.
```json
"activeUsers": {
  "2017-09": {
    "users": {
      "unId": true,
      "otroId": true
    },
    "premiumUsers": {
      "otroId": true
    }
  },
  "2017-10": {
    "users": {
      "unId": true,
      "otroIdMas": true
    },
    "premiumUsers": {
      "otroIdMas": true
    }
  }
}
```

Además se crea el endpoint `/analytics/users` para poder acceder a los datos correspondientes sobre cantidad de usuarios activos (y cuántos de éstos son premium) en un rango de fechas